### PR TITLE
particDesc indented and detailed with credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,19 @@ The Folger documentation is **[here](http://www.folgerdigitaltexts.org/fdt_docum
 Excerpt (regarding the encoding of characters):
 
 <blockquote>"Specifying who participates in a stage direction can be an interesting challenge, especially for ambiguous and permissive stage directions. We have created a new character referencing system to deal with the known and the ambiguous. Clearly identified individuals are identified with their mixed case name followed by the abbreviation of their most significant play. Thus, Hamlet is Hamlet_Ham, Falstaff is Falstaff_1H4 (even in 2H4), and the Duke of Gloucester in 3H6 is RichardIII_R3. Characters who do not have names may be identified in relation to a group of characters, expressed in capital letters. There is an attempt to develop a controlled vocabulary, so Mariners are SAILORS, Keepers are JAILERS, and Captains may be SOLDIERS. ATTENDANTS is a catch-all category that can include Lords, Gentlemen, Torchbearers, Servants, and others. A decimal-based system allows us to add more information as we have it. Brutus's soldier Titinius is SOLDIERS.BRUTUS.Titinius_JC. The First Soldier in that army is SOLDIERS.BRUTUS.1_JC. These still refer to individual characters. With messengers, for example, when we are not sure if the messenger in one scene is the same as the messenger in another, we use .X as a kind of algebraic variable. MESSENGERS.1 cannot be MESSENGERS.2, but MESSENGERS.X might be. When it is impossible to track an individual's entrances and exits, or when it is difficult to know how many characters are in the group, we prefer to track the group rather than individuals. The .0 modifier is used to single out actions by a subset of the group. If a group of ATTENDANTS enters, one is sent on an errand, and then the rest leave, that one is identified as ATTENDANTS.0.1."</blockquote>
+
+# Additional markup
+
+For the gender markup of the characters, for the distinguishing between group and individual characters, as well as the linking of the characters to the wikidata, we are grateful to
+* Бурушева Алия Асфатовна 
+* Городецкая Яна	Юрьевна
+* Дараган Карина	Михайловна
+* Жбанова Анастасия	Михайловна
+* Курышова Алина	Геннадьевна
+* Павлова Анастасия	Дмитриевна
+* Подлесная Екатерина	Марковна
+* Полякова Карина	Валерьевна
+* Рагулина Виктория	Евгеньевна
+* Синявская Нина	Игоревна
+
+

--- a/tei/a-midsummer-night-s-dream.xml
+++ b/tei/a-midsummer-night-s-dream.xml
@@ -88,79 +88,79 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Theseus_MND">
+          <person xml:id="Theseus_MND" sex="MALE">
             <persName>Theseus</persName>
           </person>
-          <person xml:id="Hippolyta_MND">
+          <person xml:id="Hippolyta_MND" sex="FEMALE">
             <persName>Hippolyta</persName>
           </person>
-          <person xml:id="Egeus_MND">
+          <person xml:id="Egeus_MND" sex="MALE">
             <persName>Egeus</persName>
           </person>
-          <person xml:id="Hermia_MND">
+          <person xml:id="Hermia_MND" sex="FEMALE">
             <persName>Hermia</persName>
           </person>
-          <person xml:id="Demetrius_MND">
+          <person xml:id="Demetrius_MND" sex="MAE">
             <persName>Demetrius</persName>
           </person>
-          <person xml:id="Lysander_MND">
+          <person xml:id="Lysander_MND" sex="MALE">
             <persName>Lysander</persName>
           </person>
-          <person xml:id="Helena_MND">
+          <person xml:id="Helena_MND" sex="FEMALE">
             <persName>Helena</persName>
           </person>
-          <person xml:id="Quince_MND">
+          <person xml:id="Quince_MND" sex="MALE">
             <persName>Peter Quince</persName>
           </person>
-          <person xml:id="Bottom_MND">
+          <person xml:id="Bottom_MND" sex="MALE">
             <persName>Nick Bottom</persName>
           </person>
-          <person xml:id="Flute_MND">
+          <person xml:id="Flute_MND" sex="MALE">
             <persName>Francis Flute</persName>
           </person>
-          <person xml:id="Starveling_MND">
+          <person xml:id="Starveling_MND" sex=" MALE">
             <persName>Robin Starveling</persName>
           </person>
-          <person xml:id="Snout_MND">
+          <person xml:id="Snout_MND" sex="MALE">
             <persName>Tom Snout</persName>
           </person>
-          <person xml:id="Snug_MND">
+          <person xml:id="Snug_MND" sex="MALE">
             <persName>Snug</persName>
           </person>
-          <person xml:id="RobinGoodfellow_MND">
+          <person xml:id="RobinGoodfellow_MND" sex="MALE">
             <persName>Robin Goodfellow</persName>
           </person>
-          <person xml:id="FAIRIES.TITANIA.1_MND">
+          <person xml:id="FAIRIES.TITANIA.1_MND" sex="FEMALE">
             <persName>A Fairy</persName>
           </person>
-          <person xml:id="Oberon_MND">
+          <person xml:id="Oberon_MND" sex="MALE">
             <persName>Oberon</persName>
           </person>
-          <person xml:id="Titania_MND">
+          <person xml:id="Titania_MND" sex="FEMALE">
             <persName>Titania</persName>
           </person>
-          <person xml:id="FAIRIES.TITANIA.0.1_MND">
-            <persName>Other Fairies in the trains of Titania and Oberon</persName>
-          </person>
-          <person xml:id="FAIRIES.TITANIA_MND">
-            <persName>Other Fairies in the trains of Titania and Oberon</persName>
-          </person>
-          <person xml:id="FAIRIES.TITANIA.0.2_MND">
-            <persName>Other Fairies in the trains of Titania and Oberon</persName>
-          </person>
-          <person xml:id="FAIRIES.TITANIA.Peaseblossom_MND">
+          <personGrp xml:id="FAIRIES.TITANIA.0.1_MND" sex="UNKNOWN">
+            <name>Other Fairies in the trains of Titania and Oberon</name>
+          </personGrp>
+          <personGrp xml:id="FAIRIES.TITANIA_MND" sex="UNKNOWN">
+            <name>Other Fairies in the trains of Titania and Oberon</name>
+          </personGrp>
+          <personGrp xml:id="FAIRIES.TITANIA.0.2_MND" sex="UNKNOWN">
+            <name>Other Fairies in the trains of Titania and Oberon</name>
+          </personGrp>
+          <person xml:id="FAIRIES.TITANIA.Peaseblossom_MND" sex="MALE">
             <persName>Peaseblossom</persName>
           </person>
-          <person xml:id="FAIRIES.TITANIA.Cobweb_MND">
+          <person xml:id="FAIRIES.TITANIA.Cobweb_MND" sex="MALE">
             <persName>Cobweb</persName>
           </person>
-          <person xml:id="FAIRIES.TITANIA.Mote_MND">
+          <person sex="" xml:id="FAIRIES.TITANIA.Mote_MND">
             <persName>Mote</persName>
           </person>
-          <person xml:id="FAIRIES.TITANIA.Mustardseed_MND">
+          <person xml:id="FAIRIES.TITANIA.Mustardseed_MND" sex="MALE">
             <persName>Mustardseed</persName>
           </person>
-          <person xml:id="Philostrate_MND">
+          <person xml:id="Philostrate_MND" sex="MALE">
             <persName>Philostrate</persName>
           </person>
         </listPerson>

--- a/tei/a-midsummer-night-s-dream.xml
+++ b/tei/a-midsummer-night-s-dream.xml
@@ -154,7 +154,7 @@
           <person xml:id="FAIRIES.TITANIA.Cobweb_MND" sex="MALE">
             <persName>Cobweb</persName>
           </person>
-          <person sex="" xml:id="FAIRIES.TITANIA.Mote_MND">
+          <person xml:id="FAIRIES.TITANIA.Mote_MND">
             <persName>Mote</persName>
           </person>
           <person xml:id="FAIRIES.TITANIA.Mustardseed_MND" sex="MALE">

--- a/tei/a-midsummer-night-s-dream.xml
+++ b/tei/a-midsummer-night-s-dream.xml
@@ -86,7 +86,86 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Theseus_MND"><persName>Theseus</persName></person><person xml:id="Hippolyta_MND"><persName>Hippolyta</persName></person><person xml:id="Egeus_MND"><persName>Egeus</persName></person><person xml:id="Hermia_MND"><persName>Hermia</persName></person><person xml:id="Demetrius_MND"><persName>Demetrius</persName></person><person xml:id="Lysander_MND"><persName>Lysander</persName></person><person xml:id="Helena_MND"><persName>Helena</persName></person><person xml:id="Quince_MND"><persName>Peter Quince</persName></person><person xml:id="Bottom_MND"><persName>Nick Bottom</persName></person><person xml:id="Flute_MND"><persName>Francis Flute</persName></person><person xml:id="Starveling_MND"><persName>Robin Starveling</persName></person><person xml:id="Snout_MND"><persName>Tom Snout</persName></person><person xml:id="Snug_MND"><persName>Snug</persName></person><person xml:id="RobinGoodfellow_MND"><persName>Robin Goodfellow</persName></person><person xml:id="FAIRIES.TITANIA.1_MND"><persName>A Fairy</persName></person><person xml:id="Oberon_MND"><persName>Oberon</persName></person><person xml:id="Titania_MND"><persName>Titania</persName></person><person xml:id="FAIRIES.TITANIA.0.1_MND"><persName>Other Fairies in the trains of Titania and Oberon</persName></person><person xml:id="FAIRIES.TITANIA_MND"><persName>Other Fairies in the trains of Titania and Oberon</persName></person><person xml:id="FAIRIES.TITANIA.0.2_MND"><persName>Other Fairies in the trains of Titania and Oberon</persName></person><person xml:id="FAIRIES.TITANIA.Peaseblossom_MND"><persName>Peaseblossom</persName></person><person xml:id="FAIRIES.TITANIA.Cobweb_MND"><persName>Cobweb</persName></person><person xml:id="FAIRIES.TITANIA.Mote_MND"><persName>Mote</persName></person><person xml:id="FAIRIES.TITANIA.Mustardseed_MND"><persName>Mustardseed</persName></person><person xml:id="Philostrate_MND"><persName>Philostrate</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Theseus_MND">
+            <persName>Theseus</persName>
+          </person>
+          <person xml:id="Hippolyta_MND">
+            <persName>Hippolyta</persName>
+          </person>
+          <person xml:id="Egeus_MND">
+            <persName>Egeus</persName>
+          </person>
+          <person xml:id="Hermia_MND">
+            <persName>Hermia</persName>
+          </person>
+          <person xml:id="Demetrius_MND">
+            <persName>Demetrius</persName>
+          </person>
+          <person xml:id="Lysander_MND">
+            <persName>Lysander</persName>
+          </person>
+          <person xml:id="Helena_MND">
+            <persName>Helena</persName>
+          </person>
+          <person xml:id="Quince_MND">
+            <persName>Peter Quince</persName>
+          </person>
+          <person xml:id="Bottom_MND">
+            <persName>Nick Bottom</persName>
+          </person>
+          <person xml:id="Flute_MND">
+            <persName>Francis Flute</persName>
+          </person>
+          <person xml:id="Starveling_MND">
+            <persName>Robin Starveling</persName>
+          </person>
+          <person xml:id="Snout_MND">
+            <persName>Tom Snout</persName>
+          </person>
+          <person xml:id="Snug_MND">
+            <persName>Snug</persName>
+          </person>
+          <person xml:id="RobinGoodfellow_MND">
+            <persName>Robin Goodfellow</persName>
+          </person>
+          <person xml:id="FAIRIES.TITANIA.1_MND">
+            <persName>A Fairy</persName>
+          </person>
+          <person xml:id="Oberon_MND">
+            <persName>Oberon</persName>
+          </person>
+          <person xml:id="Titania_MND">
+            <persName>Titania</persName>
+          </person>
+          <person xml:id="FAIRIES.TITANIA.0.1_MND">
+            <persName>Other Fairies in the trains of Titania and Oberon</persName>
+          </person>
+          <person xml:id="FAIRIES.TITANIA_MND">
+            <persName>Other Fairies in the trains of Titania and Oberon</persName>
+          </person>
+          <person xml:id="FAIRIES.TITANIA.0.2_MND">
+            <persName>Other Fairies in the trains of Titania and Oberon</persName>
+          </person>
+          <person xml:id="FAIRIES.TITANIA.Peaseblossom_MND">
+            <persName>Peaseblossom</persName>
+          </person>
+          <person xml:id="FAIRIES.TITANIA.Cobweb_MND">
+            <persName>Cobweb</persName>
+          </person>
+          <person xml:id="FAIRIES.TITANIA.Mote_MND">
+            <persName>Mote</persName>
+          </person>
+          <person xml:id="FAIRIES.TITANIA.Mustardseed_MND">
+            <persName>Mustardseed</persName>
+          </person>
+          <person xml:id="Philostrate_MND">
+            <persName>Philostrate</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/all-s-well-that-ends-well.xml
+++ b/tei/all-s-well-that-ends-well.xml
@@ -88,93 +88,93 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Countess_AWW">
+          <person xml:id="Countess_AWW" sex="FEMALE">
             <persName>Countess</persName>
           </person>
-          <person xml:id="Bertram_AWW">
+          <person xml:id="Bertram_AWW" sex="MALE">
             <persName>Bertram</persName>
           </person>
-          <person xml:id="Lafew_AWW">
+          <person xml:id="Lafew_AWW" sex="MALE">
             <persName>Lafew</persName>
           </person>
-          <person xml:id="Helen_AWW">
+          <person xml:id="Helen_AWW" sex="FEMALE">
             <persName>Helen</persName>
           </person>
-          <person xml:id="Parolles_AWW">
+          <person xml:id="Parolles_AWW" sex="MALE">
             <persName>Parolles</persName>
           </person>
-          <person xml:id="Page_AWW">
+          <person xml:id="Page_AWW" sex="MALE">
             <persName>Page</persName>
           </person>
-          <person xml:id="King_AWW">
+          <person xml:id="King_AWW" sex="MALE">
             <persName>King</persName>
           </person>
-          <person xml:id="ATTENDANTS.KING.0.1_AWW">
-            <persName>Attendants, Soldiers, Citizens of Florence, Servants</persName>
-          </person>
-          <person xml:id="ATTENDANTS.KING.0.2_AWW">
-            <persName>Attendants, Soldiers, Citizens of Florence, Servants</persName>
-          </person>
-          <person xml:id="Steward_AWW">
+          <personGrp xml:id="ATTENDANTS.KING.0.1_AWW" sex="UNKNOWN">
+            <name>Attendants, Soldiers, Citizens of Florence, Servants</name>
+          </personGrp>
+          <personGrp xml:id="ATTENDANTS.KING.0.2_AWW" sex="UNKNOWN">
+            <name>Attendants, Soldiers, Citizens of Florence, Servants</name>
+          </personGrp>
+          <person xml:id="Steward_AWW" sex="MALE">
             <persName>Steward</persName>
           </person>
-          <person xml:id="Fool_AWW">
+          <person xml:id="Fool_AWW" sex="MALE">
             <persName>Fool</persName>
           </person>
-          <person xml:id="LORDS.DUMAINE.1_AWW">
+          <person xml:id="LORDS.DUMAINE.1_AWW" sex="MALE">
             <persName>First Lord</persName>
           </person>
-          <person xml:id="LORDS.DUMAINE.2_AWW">
+          <person xml:id="LORDS.DUMAINE.2_AWW" sex="MALE">
             <persName>Second Lord</persName>
           </person>
-          <person xml:id="LORDS.COURT.1_AWW">
-            <persName>LORDS.COURT.1_AWW</persName>
-          </person>
-          <person xml:id="LORDS.COURT.2_AWW">
-            <persName>LORDS.COURT.2_AWW</persName>
-          </person>
-          <person xml:id="LORDS.COURT.3_AWW">
-            <persName>LORDS.COURT.3_AWW</persName>
-          </person>
-          <person xml:id="LORDS.COURT.4_AWW">
-            <persName>LORDS.COURT.4_AWW</persName>
-          </person>
-          <person xml:id="Duke_AWW">
+          <personGrp xml:id="LORDS.COURT.1_AWW" sex="UNKNOWN">
+            <name>LORDS.COURT.1_AWW</name>
+          </personGrp>
+          <personGrp xml:id="LORDS.COURT.2_AWW" sex="UNKNOWN">
+            <name>LORDS.COURT.2_AWW</name>
+          </personGrp>
+          <personGrp xml:id="LORDS.COURT.3_AWW" sex="UNKNOWN">
+            <name>LORDS.COURT.3_AWW</name>
+          </personGrp>
+          <personGrp xml:id="LORDS.COURT.4_AWW" sex="UNKNOWN">
+            <name>LORDS.COURT.4_AWW</name>
+          </personGrp>
+          <person xml:id="Duke_AWW" sex="MALE">
             <persName>Duke</persName>
           </person>
-          <person xml:id="GENTLEMEN.1_AWW">
+          <person xml:id="GENTLEMEN.1_AWW" sex="MALE">
             <persName>First Gentleman</persName>
           </person>
-          <person xml:id="GENTLEMEN.2_AWW">
+          <person xml:id="GENTLEMEN.2_AWW" sex="MALE">
             <persName>Second Gentleman</persName>
           </person>
-          <person xml:id="Widow_AWW">
+          <person xml:id="Widow_AWW" sex="FEMALE">
             <persName>Widow</persName>
           </person>
-          <person xml:id="Diana_AWW">
+          <person xml:id="Diana_AWW" sex="FEMALE">
             <persName>Diana</persName>
           </person>
-          <person xml:id="Mariana_AWW">
+          <person xml:id="Mariana_AWW" sex="FEMALE">
             <persName>Mariana</persName>
           </person>
-          <person xml:id="SOLDIERS.Interpreter_AWW">
+          <person xml:id="SOLDIERS.Interpreter_AWW" sex="MALE">
             <persName>First Soldier</persName>
           </person>
-          <person xml:id="SOLDIERS_AWW">
-            <persName>Attendants, Soldiers, Citizens of Florence, Servants</persName>
-          </person>
-          <person xml:id="SOLDIERS.0.1_AWW">
-            <persName>Attendants, Soldiers, Citizens of Florence, Servants</persName>
-          </person>
-          <person xml:id="Servant_AWW">
-            <persName>Attendants, Soldiers, Citizens of Florence, Servants</persName>
-          </person>
-          <person xml:id="GENTLEMEN.3_AWW">
+          <personGrp xml:id="SOLDIERS_AWW" sex="UNKNOWN">
+            <name>Attendants, Soldiers, Citizens of Florence, Servants</name>
+          </personGrp>
+          <personGrp xml:id="SOLDIERS.0.1_AWW" sex="UNKNOWN">
+            <name>Attendants, Soldiers, Citizens of Florence, Servants</name>
+          </personGrp>
+          <personGrp xml:id="Servant_AWW" sex="UNKNOWN">
+            <name>Attendants, Soldiers, Citizens of Florence, Servants</name>
+          </personGrp>
+          <person xml:id="GENTLEMEN.3_AWW" sex="MALE">
             <persName>Gentleman</persName>
           </person>
-          <person xml:id="Epilogue_AWW">
-            <persName>Attendants, Soldiers, Citizens of Florence, Servants</persName>
-          </person>
+          <personGrp xml:id="Epilogue_AWW" sex="UNKNOWN">
+            <name>Attendants, Soldiers, Citizens of Florence, Servants</name>
+          </personGrp>
         </listPerson>
       </particDesc>
     </profileDesc>

--- a/tei/all-s-well-that-ends-well.xml
+++ b/tei/all-s-well-that-ends-well.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts encodes the edition of each play by Barbara Mowat and Paul Werstine in TEI Simple. The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptionss and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,98 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Countess_AWW"><persName>Countess</persName></person><person xml:id="Bertram_AWW"><persName>Bertram</persName></person><person xml:id="Lafew_AWW"><persName>Lafew</persName></person><person xml:id="Helen_AWW"><persName>Helen</persName></person><person xml:id="Parolles_AWW"><persName>Parolles</persName></person><person xml:id="Page_AWW"><persName>Page</persName></person><person xml:id="King_AWW"><persName>King</persName></person><person xml:id="ATTENDANTS.KING.0.1_AWW"><persName>Attendants, Soldiers, Citizens of Florence, Servants</persName></person><person xml:id="ATTENDANTS.KING.0.2_AWW"><persName>Attendants, Soldiers, Citizens of Florence, Servants</persName></person><person xml:id="Steward_AWW"><persName>Steward</persName></person><person xml:id="Fool_AWW"><persName>Fool</persName></person><person xml:id="LORDS.DUMAINE.1_AWW"><persName>First Lord</persName></person><person xml:id="LORDS.DUMAINE.2_AWW"><persName>Second Lord</persName></person><person xml:id="LORDS.COURT.1_AWW"><persName>LORDS.COURT.1_AWW</persName></person><person xml:id="LORDS.COURT.2_AWW"><persName>LORDS.COURT.2_AWW</persName></person><person xml:id="LORDS.COURT.3_AWW"><persName>LORDS.COURT.3_AWW</persName></person><person xml:id="LORDS.COURT.4_AWW"><persName>LORDS.COURT.4_AWW</persName></person><person xml:id="Duke_AWW"><persName>Duke</persName></person><person xml:id="GENTLEMEN.1_AWW"><persName>First Gentleman</persName></person><person xml:id="GENTLEMEN.2_AWW"><persName>Second Gentleman</persName></person><person xml:id="Widow_AWW"><persName>Widow</persName></person><person xml:id="Diana_AWW"><persName>Diana</persName></person><person xml:id="Mariana_AWW"><persName>Mariana</persName></person><person xml:id="SOLDIERS.Interpreter_AWW"><persName>First Soldier</persName></person><person xml:id="SOLDIERS_AWW"><persName>Attendants, Soldiers, Citizens of Florence, Servants</persName></person><person xml:id="SOLDIERS.0.1_AWW"><persName>Attendants, Soldiers, Citizens of Florence, Servants</persName></person><person xml:id="Servant_AWW"><persName>Attendants, Soldiers, Citizens of Florence, Servants</persName></person><person xml:id="GENTLEMEN.3_AWW"><persName>Gentleman</persName></person><person xml:id="Epilogue_AWW"><persName>Attendants, Soldiers, Citizens of Florence, Servants</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Countess_AWW">
+            <persName>Countess</persName>
+          </person>
+          <person xml:id="Bertram_AWW">
+            <persName>Bertram</persName>
+          </person>
+          <person xml:id="Lafew_AWW">
+            <persName>Lafew</persName>
+          </person>
+          <person xml:id="Helen_AWW">
+            <persName>Helen</persName>
+          </person>
+          <person xml:id="Parolles_AWW">
+            <persName>Parolles</persName>
+          </person>
+          <person xml:id="Page_AWW">
+            <persName>Page</persName>
+          </person>
+          <person xml:id="King_AWW">
+            <persName>King</persName>
+          </person>
+          <person xml:id="ATTENDANTS.KING.0.1_AWW">
+            <persName>Attendants, Soldiers, Citizens of Florence, Servants</persName>
+          </person>
+          <person xml:id="ATTENDANTS.KING.0.2_AWW">
+            <persName>Attendants, Soldiers, Citizens of Florence, Servants</persName>
+          </person>
+          <person xml:id="Steward_AWW">
+            <persName>Steward</persName>
+          </person>
+          <person xml:id="Fool_AWW">
+            <persName>Fool</persName>
+          </person>
+          <person xml:id="LORDS.DUMAINE.1_AWW">
+            <persName>First Lord</persName>
+          </person>
+          <person xml:id="LORDS.DUMAINE.2_AWW">
+            <persName>Second Lord</persName>
+          </person>
+          <person xml:id="LORDS.COURT.1_AWW">
+            <persName>LORDS.COURT.1_AWW</persName>
+          </person>
+          <person xml:id="LORDS.COURT.2_AWW">
+            <persName>LORDS.COURT.2_AWW</persName>
+          </person>
+          <person xml:id="LORDS.COURT.3_AWW">
+            <persName>LORDS.COURT.3_AWW</persName>
+          </person>
+          <person xml:id="LORDS.COURT.4_AWW">
+            <persName>LORDS.COURT.4_AWW</persName>
+          </person>
+          <person xml:id="Duke_AWW">
+            <persName>Duke</persName>
+          </person>
+          <person xml:id="GENTLEMEN.1_AWW">
+            <persName>First Gentleman</persName>
+          </person>
+          <person xml:id="GENTLEMEN.2_AWW">
+            <persName>Second Gentleman</persName>
+          </person>
+          <person xml:id="Widow_AWW">
+            <persName>Widow</persName>
+          </person>
+          <person xml:id="Diana_AWW">
+            <persName>Diana</persName>
+          </person>
+          <person xml:id="Mariana_AWW">
+            <persName>Mariana</persName>
+          </person>
+          <person xml:id="SOLDIERS.Interpreter_AWW">
+            <persName>First Soldier</persName>
+          </person>
+          <person xml:id="SOLDIERS_AWW">
+            <persName>Attendants, Soldiers, Citizens of Florence, Servants</persName>
+          </person>
+          <person xml:id="SOLDIERS.0.1_AWW">
+            <persName>Attendants, Soldiers, Citizens of Florence, Servants</persName>
+          </person>
+          <person xml:id="Servant_AWW">
+            <persName>Attendants, Soldiers, Citizens of Florence, Servants</persName>
+          </person>
+          <person xml:id="GENTLEMEN.3_AWW">
+            <persName>Gentleman</persName>
+          </person>
+          <person xml:id="Epilogue_AWW">
+            <persName>Attendants, Soldiers, Citizens of Florence, Servants</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/antony-and-cleopatra.xml
+++ b/tei/antony-and-cleopatra.xml
@@ -88,229 +88,229 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Philo_Ant">
+          <person xml:id="Philo_Ant" sex="MALE">
             <persName>Philo</persName>
           </person>
-          <person xml:id="Cleopatra_Ant">
+          <person xml:id="Cleopatra_Ant" ana="http://www.wikidata.org/entity/Q635">
             <persName>Cleopatra</persName>
           </person>
-          <person xml:id="Antony_JC">
+          <person xml:id="Antony_JC" ana="http://www.wikidata.org/entity/Q51673">
             <persName>Antony</persName>
           </person>
-          <person xml:id="MESSENGERS.X.1_Ant">
+          <person xml:id="MESSENGERS.X.1_Ant" sex="MALE">
             <persName>MESSENGERS.X.1_Ant</persName>
           </person>
-          <person xml:id="Demetrius_Ant">
+          <person xml:id="Demetrius_Ant" sex="MALE">
             <persName>Demetrius</persName>
           </person>
-          <person xml:id="Charmian_Ant">
+          <person xml:id="Charmian_Ant" ana="http://www.wikidata.org/entity/Q5086521">
             <persName>Charmian</persName>
           </person>
-          <person xml:id="Alexas_Ant">
+          <person xml:id="Alexas_Ant" sex="MALE">
             <persName>Alexas</persName>
           </person>
-          <person xml:id="Soothsayer_Ant">
+          <person xml:id="Soothsayer_Ant" sex="MALE">
             <persName>A Soothsayer</persName>
           </person>
-          <person xml:id="Enobarbus_Ant">
+          <person xml:id="Enobarbus_Ant" ana="http://www.wikidata.org/entity/Q360920">
             <persName>Enobarbus Domitius</persName>
             <persName>Enobarbus Domitius</persName>
           </person>
-          <person xml:id="Iras_Ant">
+          <person xml:id="Iras_Ant" sex="FEMALE">
             <persName>Iras</persName>
           </person>
-          <person xml:id="MESSENGERS.ANTONY.1_Ant">
+          <person xml:id="MESSENGERS.ANTONY.1_Ant" sex="MALE">
             <persName>MESSENGERS.ANTONY.1_Ant</persName>
           </person>
-          <person xml:id="MESSENGERS.ANTONY.2_Ant">
+          <person xml:id="MESSENGERS.ANTONY.2_Ant" sex="MALE">
             <persName>MESSENGERS.ANTONY.2_Ant</persName>
           </person>
-          <person xml:id="MESSENGERS.ANTONY.3_Ant">
+          <person xml:id="MESSENGERS.ANTONY.3_Ant" sex="MALE">
             <persName>MESSENGERS.ANTONY.3_Ant</persName>
           </person>
-          <person xml:id="Octavius_JC">
+          <person xml:id="Octavius_JC" ana="http://www.wikidata.org/entity/Q1405">
             <persName>Octavius Caesar</persName>
           </person>
-          <person xml:id="Lepidus_JC">
+          <person xml:id="Lepidus_JC" ana="http://www.wikidata.org/entity/Q105452">
             <persName>Lepidus</persName>
           </person>
-          <person xml:id="MESSENGERS.CAESAR.1_Ant">
+          <person xml:id="MESSENGERS.CAESAR.1_Ant" sex="MALE">
             <persName>MESSENGERS.CAESAR.1_Ant</persName>
           </person>
-          <person xml:id="MESSENGERS.CAESAR.2_Ant">
+          <person xml:id="MESSENGERS.CAESAR.2_Ant" sex="MALE">
             <persName>MESSENGERS.CAESAR.2_Ant</persName>
           </person>
-          <person xml:id="Mardian_Ant">
+          <person xml:id="Mardian_Ant" sex="MALE">
             <persName>Mardian</persName>
           </person>
-          <person xml:id="Pompey_Ant">
+          <person xml:id="Pompey_Ant" ana="http://www.wikidata.org/entity/Q295228">
             <persName>Sextus Pompeius Pompey</persName>
             <persName>Sextus Pompeius Pompey</persName>
           </person>
-          <person xml:id="Menas_Ant">
+          <person xml:id="Menas_Ant" ana="http://www.wikidata.org/entity/Q1283531">
             <persName>Menas</persName>
           </person>
-          <person xml:id="Varrius_Ant">
+          <person xml:id="Varrius_Ant" sex="MALE">
             <persName>Varrius</persName>
           </person>
-          <person xml:id="Maecenas_Ant">
+          <person xml:id="Maecenas_Ant" ana="http://www.wikidata.org/entity/Q8833">
             <persName>Maecenas</persName>
           </person>
-          <person xml:id="Agrippa_Ant">
+          <person xml:id="Agrippa_Ant" ana="http://www.wikidata.org/entity/Q48174">
             <persName>Agrippa</persName>
           </person>
-          <person xml:id="Octavia_Ant">
+          <person xml:id="Octavia_Ant" ana="http://www.wikidata.org/entity/Q229483">
             <persName>Octavia</persName>
           </person>
-          <person xml:id="MESSENGERS.X.2_Ant">
+          <person xml:id="MESSENGERS.X.2_Ant" sex="MALE">
             <persName>MESSENGERS.X.2_Ant</persName>
           </person>
-          <person xml:id="SERVANTS.0.1_Ant">
-            <persName>SERVANTS.0.1_Ant</persName>
-          </person>
-          <person xml:id="SERVANTS.0.2_Ant">
-            <persName>SERVANTS.0.2_Ant</persName>
-          </person>
-          <person xml:id="Boy_Ant">
+          <personGrp xml:id="SERVANTS.0.1_Ant" sex="UNKNOWN">
+            <name>SERVANTS.0.1_Ant</name>
+          </personGrp>
+          <personGrp xml:id="SERVANTS.0.2_Ant" sex="UNKNOWN">
+            <name>SERVANTS.0.2_Ant</name>
+          </personGrp>
+          <person xml:id="Boy_Ant" sex="MALE">
             <persName>A Boy</persName>
           </person>
-          <person xml:id="CAPTAINS_Ant">
+          <person xml:id="CAPTAINS_Ant" sex="MALE">
             <persName>CAPTAINS_Ant</persName>
           </person>
-          <person xml:id="Ventidius_Ant">
+          <person xml:id="Ventidius_Ant" ana="http://www.wikidata.org/entity/Q521552">
             <persName>Ventidius</persName>
           </person>
-          <person xml:id="Silius_Ant">
+          <person xml:id="Silius_Ant" sex="MALE">
             <persName>Silius</persName>
           </person>
-          <person xml:id="Eros_Ant">
+          <person xml:id="Eros_Ant" sex="MALE">
             <persName>Eros</persName>
           </person>
-          <person xml:id="Canidius_Ant">
+          <person xml:id="Canidius_Ant" ana="http://www.wikidata.org/entity/Q637205">
             <persName>Canidius</persName>
           </person>
-          <person xml:id="MESSENGERS.X.3_Ant">
-            <persName>MESSENGERS.X.3_Ant</persName>
-          </person>
-          <person xml:id="SOLDIERS.ANTONY.X.1_Ant">
-            <persName>SOLDIERS.ANTONY.X.1_Ant</persName>
-          </person>
-          <person xml:id="MESSENGERS.X.4_Ant">
-            <persName>MESSENGERS.X.4_Ant</persName>
-          </person>
-          <person xml:id="Taurus_Ant">
+          <personGrp xml:id="MESSENGERS.X.3_Ant" sex="UNKNOWN">
+            <name>MESSENGERS.X.3_Ant</name>
+          </personGrp>
+          <personGrp xml:id="SOLDIERS.ANTONY.X.1_Ant" sex="UNKNOWN">
+            <name>SOLDIERS.ANTONY.X.1_Ant</name>
+          </personGrp>
+          <personGrp xml:id="MESSENGERS.X.4_Ant" sex="UNKNOWN">
+            <name>MESSENGERS.X.4_Ant</name>
+          </personGrp>
+          <person xml:id="Taurus_Ant" ana="http://www.wikidata.org/entity/Q2331658">
             <persName>Taurus</persName>
           </person>
-          <person xml:id="Scarus_Ant">
+          <person xml:id="Scarus_Ant" ana="http://www.wikidata.org/entity/Q3655539">
             <persName>Scarus</persName>
           </person>
-          <person xml:id="ATTENDANTS.ANTONY_Ant">
-            <persName>ATTENDANTS.ANTONY_Ant</persName>
-          </person>
-          <person xml:id="Dolabella_Ant">
+          <personGrp xml:id="ATTENDANTS.ANTONY_Ant" sex="UNKNOWN">
+            <name>ATTENDANTS.ANTONY_Ant</name>
+          </personGrp>
+          <person xml:id="Dolabella_Ant" ana="http://www.wikidata.org/entity/Q451597">
             <persName>Dolabella</persName>
           </person>
-          <person xml:id="Ambassador_Ant">
+          <person xml:id="Ambassador_Ant" sex="MALE">
             <persName>A Schoolmaster Ambassador</persName>
             <persName>A Schoolmaster Ambassador</persName>
           </person>
-          <person xml:id="Thidias_Ant">
+          <person xml:id="Thidias_Ant" sex="MALE">
             <persName>Thidias</persName>
           </person>
-          <person xml:id="SERVANTS.X.1_Ant">
-            <persName>SERVANTS.X.1_Ant</persName>
-          </person>
-          <person xml:id="SERVANTS.X.2_Ant">
-            <persName>SERVANTS.X.2_Ant</persName>
-          </person>
-          <person xml:id="SERVANTS_Ant">
-            <persName>Servants</persName>
-          </person>
-          <person xml:id="SOLDIERS.ANTONY.0.1_Ant">
-            <persName>SOLDIERS.ANTONY.0.1_Ant</persName>
-          </person>
-          <person xml:id="SOLDIERS.ANTONY.0.2_Ant">
-            <persName>SOLDIERS.ANTONY.0.2_Ant</persName>
-          </person>
-          <person xml:id="SOLDIERS.ANTONY.0.3_Ant">
-            <persName>SOLDIERS.ANTONY.0.3_Ant</persName>
-          </person>
-          <person xml:id="SOLDIERS.ANTONY.0.4_Ant">
-            <persName>SOLDIERS.ANTONY.0.4_Ant</persName>
-          </person>
-          <person xml:id="SOLDIERS.ANTONY_Ant">
-            <persName>SOLDIERS.ANTONY_Ant</persName>
-          </person>
-          <person xml:id="SOLDIERS.ANTONY.X.2_Ant">
-            <persName>SOLDIERS.ANTONY.X.2_Ant</persName>
-          </person>
-          <person xml:id="CAPTAINS.0.1_Ant">
+          <personGrp xml:id="SERVANTS.X.1_Ant" sex="UNKNOWN">
+            <name>SERVANTS.X.1_Ant</name>
+          </personGrp>
+          <personGrp xml:id="SERVANTS.X.2_Ant" sex="UNKNOWN">
+            <name>SERVANTS.X.2_Ant</name>
+          </personGrp>
+          <personGrp xml:id="SERVANTS_Ant" sex="UNKNOWN">
+            <name>Servants</name>
+          </personGrp>
+          <personGrp xml:id="SOLDIERS.ANTONY.0.1_Ant" sex="UNKNOWN">
+            <name>SOLDIERS.ANTONY.0.1_Ant</name>
+          </personGrp>
+          <personGrp xml:id="SOLDIERS.ANTONY.0.2_Ant" sex="UNKNOWN">
+            <name>SOLDIERS.ANTONY.0.2_Ant</name>
+          </personGrp>
+          <personGrp xml:id="SOLDIERS.ANTONY.0.3_Ant" sex="UNKNOWN">
+            <name>SOLDIERS.ANTONY.0.3_Ant</name>
+          </personGrp>
+          <personGrp xml:id="SOLDIERS.ANTONY.0.4_Ant" sex="UNKNOWN">
+            <name>SOLDIERS.ANTONY.0.4_Ant</name>
+          </personGrp>
+          <personGrp xml:id="SOLDIERS.ANTONY_Ant" sex="UNKNOWN">
+            <name>SOLDIERS.ANTONY_Ant</name>
+          </personGrp>
+          <personGrp xml:id="SOLDIERS.ANTONY.X.2_Ant" sex="UNKNOWN">
+            <name>SOLDIERS.ANTONY.X.2_Ant</name>
+          </personGrp>
+          <person xml:id="CAPTAINS.0.1_Ant" sex="MALE">
             <persName>A Captain</persName>
           </person>
-          <person xml:id="SOLDIERS.ANTONY.X.3_Ant">
-            <persName>SOLDIERS.ANTONY.X.3_Ant</persName>
-          </person>
-          <person xml:id="MESSENGERS.X.5_Ant">
-            <persName>MESSENGERS.X.5_Ant</persName>
-          </person>
-          <person xml:id="SOLDIERS.CAESAR.X.1_Ant">
-            <persName>SOLDIERS.CAESAR.X.1_Ant</persName>
-          </person>
-          <person xml:id="WATCHMEN.Sentry_Ant">
-            <persName>WATCHMEN.Sentry_Ant</persName>
-          </person>
-          <person xml:id="WATCHMEN.1_Ant">
+          <personGrp xml:id="SOLDIERS.ANTONY.X.3_Ant" sex="UNKNOWN">
+            <name>SOLDIERS.ANTONY.X.3_Ant</name>
+          </personGrp>
+          <personGrp xml:id="MESSENGERS.X.5_Ant" sex="UNKNOWN">
+            <name>MESSENGERS.X.5_Ant</name>
+          </personGrp>
+          <personGrp xml:id="SOLDIERS.CAESAR.X.1_Ant" sex="UNKNOWN">
+            <name>SOLDIERS.CAESAR.X.1_Ant</name>
+          </personGrp>
+          <personGrp xml:id="WATCHMEN.Sentry_Ant" sex="UNKNOWN">
+            <name>WATCHMEN.Sentry_Ant</name>
+          </personGrp>
+          <person xml:id="WATCHMEN.1_Ant" sex="MALE">
             <persName>WATCHMEN.1_Ant</persName>
           </person>
-          <person xml:id="WATCHMEN.2_Ant">
+          <person xml:id="WATCHMEN.2_Ant" sex="MALE">
             <persName>WATCHMEN.2_Ant</persName>
           </person>
-          <person xml:id="GUARDS.0.1_Ant">
+          <person xml:id="GUARDS.0.1_Ant" sex="MALE">
             <persName>GUARDS.0.1_Ant</persName>
           </person>
-          <person xml:id="GUARDS.0.2_Ant">
+          <person xml:id="GUARDS.0.2_Ant" sex="MALE">
             <persName>GUARDS.0.2_Ant</persName>
           </person>
-          <person xml:id="GUARDS_Ant">
-            <persName>Guardsmen</persName>
-          </person>
-          <person xml:id="GUARDS.Dercetus_Ant">
+          <personGrp xml:id="GUARDS_Ant" sex="UNKNOWN">
+            <name>Guardsmen</name>
+          </personGrp>
+          <person xml:id="GUARDS.Dercetus_Ant" sex="MALE">
             <persName>Dercetus</persName>
           </person>
-          <person xml:id="GUARDS.0.3_Ant">
+          <person xml:id="GUARDS.0.3_Ant" sex="MALE">
             <persName>GUARDS.0.3_Ant</persName>
           </person>
-          <person xml:id="Diomedes_Ant">
+          <person xml:id="Diomedes_Ant" sex="MALE">
             <persName>Diomedes</persName>
           </person>
-          <person xml:id="LADIES_Ant">
-            <persName>LADIES_Ant</persName>
-          </person>
-          <person xml:id="Egyptian_Ant">
+          <personGrp xml:id="LADIES_Ant" sex="UNKNOWN">
+            <name>LADIES_Ant</name>
+          </personGrp>
+          <person xml:id="Egyptian_Ant" sex="MALE">
             <persName>An Egyptian</persName>
           </person>
-          <person xml:id="Proculeius_Ant">
+          <person xml:id="Proculeius_Ant" ana="http://www.wikidata.org/entity/Q1491494">
             <persName>Proculeius</persName>
           </person>
-          <person xml:id="Gallus_Ant">
+          <person xml:id="Gallus_Ant" sex="MALE">
             <persName>Gallus</persName>
           </person>
-          <person xml:id="ATTENDANTS.CAESAR_Ant">
-            <persName>ATTENDANTS.CAESAR_Ant</persName>
-          </person>
-          <person xml:id="Seleucus_Ant">
+          <personGrp xml:id="ATTENDANTS.CAESAR_Ant" sex="UNKNOWN">
+            <name>ATTENDANTS.CAESAR_Ant</name>
+          </personGrp>
+          <person xml:id="Seleucus_Ant" ana="http://www.wikidata.org/entity/Q575798">
             <persName>Seleucus</persName>
           </person>
-          <person xml:id="GUARDS.CAESAR.1_Ant">
+          <person xml:id="GUARDS.CAESAR.1_Ant" sex="MALE">
             <persName>GUARDS.CAESAR.1_Ant</persName>
           </person>
-          <person xml:id="Countryman_Ant">
+          <person xml:id="Countryman_Ant" sex="MALE">
             <persName>A Countryman</persName>
           </person>
-          <person xml:id="GUARDS.CAESAR.0.1_Ant">
+          <person xml:id="GUARDS.CAESAR.0.1_Ant" sex="MALE">
             <persName>GUARDS.CAESAR.0.1_Ant</persName>
           </person>
-          <person xml:id="GUARDS.CAESAR.0.2_Ant">
+          <person xml:id="GUARDS.CAESAR.0.2_Ant" sex="MALE">
             <persName>GUARDS.CAESAR.0.2_Ant</persName>
           </person>
         </listPerson>

--- a/tei/antony-and-cleopatra.xml
+++ b/tei/antony-and-cleopatra.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts encodes the edition of each play by Barbara Mowat and Paul Werstine in TEI Simple. The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptionss and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,236 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Philo_Ant"><persName>Philo</persName></person><person xml:id="Cleopatra_Ant"><persName>Cleopatra</persName></person><person xml:id="Antony_JC"><persName>Antony</persName></person><person xml:id="MESSENGERS.X.1_Ant"><persName>MESSENGERS.X.1_Ant</persName></person><person xml:id="Demetrius_Ant"><persName>Demetrius</persName></person><person xml:id="Charmian_Ant"><persName>Charmian</persName></person><person xml:id="Alexas_Ant"><persName>Alexas</persName></person><person xml:id="Soothsayer_Ant"><persName>A Soothsayer</persName></person><person xml:id="Enobarbus_Ant"><persName>Enobarbus Domitius</persName><persName>Enobarbus Domitius</persName></person><person xml:id="Iras_Ant"><persName>Iras</persName></person><person xml:id="MESSENGERS.ANTONY.1_Ant"><persName>MESSENGERS.ANTONY.1_Ant</persName></person><person xml:id="MESSENGERS.ANTONY.2_Ant"><persName>MESSENGERS.ANTONY.2_Ant</persName></person><person xml:id="MESSENGERS.ANTONY.3_Ant"><persName>MESSENGERS.ANTONY.3_Ant</persName></person><person xml:id="Octavius_JC"><persName>Octavius Caesar</persName></person><person xml:id="Lepidus_JC"><persName>Lepidus</persName></person><person xml:id="MESSENGERS.CAESAR.1_Ant"><persName>MESSENGERS.CAESAR.1_Ant</persName></person><person xml:id="MESSENGERS.CAESAR.2_Ant"><persName>MESSENGERS.CAESAR.2_Ant</persName></person><person xml:id="Mardian_Ant"><persName>Mardian</persName></person><person xml:id="Pompey_Ant"><persName>Sextus Pompeius Pompey</persName><persName>Sextus Pompeius Pompey</persName></person><person xml:id="Menas_Ant"><persName>Menas</persName></person><person xml:id="Varrius_Ant"><persName>Varrius</persName></person><person xml:id="Maecenas_Ant"><persName>Maecenas</persName></person><person xml:id="Agrippa_Ant"><persName>Agrippa</persName></person><person xml:id="Octavia_Ant"><persName>Octavia</persName></person><person xml:id="MESSENGERS.X.2_Ant"><persName>MESSENGERS.X.2_Ant</persName></person><person xml:id="SERVANTS.0.1_Ant"><persName>SERVANTS.0.1_Ant</persName></person><person xml:id="SERVANTS.0.2_Ant"><persName>SERVANTS.0.2_Ant</persName></person><person xml:id="Boy_Ant"><persName>A Boy</persName></person><person xml:id="CAPTAINS_Ant"><persName>CAPTAINS_Ant</persName></person><person xml:id="Ventidius_Ant"><persName>Ventidius</persName></person><person xml:id="Silius_Ant"><persName>Silius</persName></person><person xml:id="Eros_Ant"><persName>Eros</persName></person><person xml:id="Canidius_Ant"><persName>Canidius</persName></person><person xml:id="MESSENGERS.X.3_Ant"><persName>MESSENGERS.X.3_Ant</persName></person><person xml:id="SOLDIERS.ANTONY.X.1_Ant"><persName>SOLDIERS.ANTONY.X.1_Ant</persName></person><person xml:id="MESSENGERS.X.4_Ant"><persName>MESSENGERS.X.4_Ant</persName></person><person xml:id="Taurus_Ant"><persName>Taurus</persName></person><person xml:id="Scarus_Ant"><persName>Scarus</persName></person><person xml:id="ATTENDANTS.ANTONY_Ant"><persName>ATTENDANTS.ANTONY_Ant</persName></person><person xml:id="Dolabella_Ant"><persName>Dolabella</persName></person><person xml:id="Ambassador_Ant"><persName>A Schoolmaster Ambassador</persName><persName>A Schoolmaster Ambassador</persName></person><person xml:id="Thidias_Ant"><persName>Thidias</persName></person><person xml:id="SERVANTS.X.1_Ant"><persName>SERVANTS.X.1_Ant</persName></person><person xml:id="SERVANTS.X.2_Ant"><persName>SERVANTS.X.2_Ant</persName></person><person xml:id="SERVANTS_Ant"><persName>Servants</persName></person><person xml:id="SOLDIERS.ANTONY.0.1_Ant"><persName>SOLDIERS.ANTONY.0.1_Ant</persName></person><person xml:id="SOLDIERS.ANTONY.0.2_Ant"><persName>SOLDIERS.ANTONY.0.2_Ant</persName></person><person xml:id="SOLDIERS.ANTONY.0.3_Ant"><persName>SOLDIERS.ANTONY.0.3_Ant</persName></person><person xml:id="SOLDIERS.ANTONY.0.4_Ant"><persName>SOLDIERS.ANTONY.0.4_Ant</persName></person><person xml:id="SOLDIERS.ANTONY_Ant"><persName>SOLDIERS.ANTONY_Ant</persName></person><person xml:id="SOLDIERS.ANTONY.X.2_Ant"><persName>SOLDIERS.ANTONY.X.2_Ant</persName></person><person xml:id="CAPTAINS.0.1_Ant"><persName>A Captain</persName></person><person xml:id="SOLDIERS.ANTONY.X.3_Ant"><persName>SOLDIERS.ANTONY.X.3_Ant</persName></person><person xml:id="MESSENGERS.X.5_Ant"><persName>MESSENGERS.X.5_Ant</persName></person><person xml:id="SOLDIERS.CAESAR.X.1_Ant"><persName>SOLDIERS.CAESAR.X.1_Ant</persName></person><person xml:id="WATCHMEN.Sentry_Ant"><persName>WATCHMEN.Sentry_Ant</persName></person><person xml:id="WATCHMEN.1_Ant"><persName>WATCHMEN.1_Ant</persName></person><person xml:id="WATCHMEN.2_Ant"><persName>WATCHMEN.2_Ant</persName></person><person xml:id="GUARDS.0.1_Ant"><persName>GUARDS.0.1_Ant</persName></person><person xml:id="GUARDS.0.2_Ant"><persName>GUARDS.0.2_Ant</persName></person><person xml:id="GUARDS_Ant"><persName>Guardsmen</persName></person><person xml:id="GUARDS.Dercetus_Ant"><persName>Dercetus</persName></person><person xml:id="GUARDS.0.3_Ant"><persName>GUARDS.0.3_Ant</persName></person><person xml:id="Diomedes_Ant"><persName>Diomedes</persName></person><person xml:id="LADIES_Ant"><persName>LADIES_Ant</persName></person><person xml:id="Egyptian_Ant"><persName>An Egyptian</persName></person><person xml:id="Proculeius_Ant"><persName>Proculeius</persName></person><person xml:id="Gallus_Ant"><persName>Gallus</persName></person><person xml:id="ATTENDANTS.CAESAR_Ant"><persName>ATTENDANTS.CAESAR_Ant</persName></person><person xml:id="Seleucus_Ant"><persName>Seleucus</persName></person><person xml:id="GUARDS.CAESAR.1_Ant"><persName>GUARDS.CAESAR.1_Ant</persName></person><person xml:id="Countryman_Ant"><persName>A Countryman</persName></person><person xml:id="GUARDS.CAESAR.0.1_Ant"><persName>GUARDS.CAESAR.0.1_Ant</persName></person><person xml:id="GUARDS.CAESAR.0.2_Ant"><persName>GUARDS.CAESAR.0.2_Ant</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Philo_Ant">
+            <persName>Philo</persName>
+          </person>
+          <person xml:id="Cleopatra_Ant">
+            <persName>Cleopatra</persName>
+          </person>
+          <person xml:id="Antony_JC">
+            <persName>Antony</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.1_Ant">
+            <persName>MESSENGERS.X.1_Ant</persName>
+          </person>
+          <person xml:id="Demetrius_Ant">
+            <persName>Demetrius</persName>
+          </person>
+          <person xml:id="Charmian_Ant">
+            <persName>Charmian</persName>
+          </person>
+          <person xml:id="Alexas_Ant">
+            <persName>Alexas</persName>
+          </person>
+          <person xml:id="Soothsayer_Ant">
+            <persName>A Soothsayer</persName>
+          </person>
+          <person xml:id="Enobarbus_Ant">
+            <persName>Enobarbus Domitius</persName>
+            <persName>Enobarbus Domitius</persName>
+          </person>
+          <person xml:id="Iras_Ant">
+            <persName>Iras</persName>
+          </person>
+          <person xml:id="MESSENGERS.ANTONY.1_Ant">
+            <persName>MESSENGERS.ANTONY.1_Ant</persName>
+          </person>
+          <person xml:id="MESSENGERS.ANTONY.2_Ant">
+            <persName>MESSENGERS.ANTONY.2_Ant</persName>
+          </person>
+          <person xml:id="MESSENGERS.ANTONY.3_Ant">
+            <persName>MESSENGERS.ANTONY.3_Ant</persName>
+          </person>
+          <person xml:id="Octavius_JC">
+            <persName>Octavius Caesar</persName>
+          </person>
+          <person xml:id="Lepidus_JC">
+            <persName>Lepidus</persName>
+          </person>
+          <person xml:id="MESSENGERS.CAESAR.1_Ant">
+            <persName>MESSENGERS.CAESAR.1_Ant</persName>
+          </person>
+          <person xml:id="MESSENGERS.CAESAR.2_Ant">
+            <persName>MESSENGERS.CAESAR.2_Ant</persName>
+          </person>
+          <person xml:id="Mardian_Ant">
+            <persName>Mardian</persName>
+          </person>
+          <person xml:id="Pompey_Ant">
+            <persName>Sextus Pompeius Pompey</persName>
+            <persName>Sextus Pompeius Pompey</persName>
+          </person>
+          <person xml:id="Menas_Ant">
+            <persName>Menas</persName>
+          </person>
+          <person xml:id="Varrius_Ant">
+            <persName>Varrius</persName>
+          </person>
+          <person xml:id="Maecenas_Ant">
+            <persName>Maecenas</persName>
+          </person>
+          <person xml:id="Agrippa_Ant">
+            <persName>Agrippa</persName>
+          </person>
+          <person xml:id="Octavia_Ant">
+            <persName>Octavia</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.2_Ant">
+            <persName>MESSENGERS.X.2_Ant</persName>
+          </person>
+          <person xml:id="SERVANTS.0.1_Ant">
+            <persName>SERVANTS.0.1_Ant</persName>
+          </person>
+          <person xml:id="SERVANTS.0.2_Ant">
+            <persName>SERVANTS.0.2_Ant</persName>
+          </person>
+          <person xml:id="Boy_Ant">
+            <persName>A Boy</persName>
+          </person>
+          <person xml:id="CAPTAINS_Ant">
+            <persName>CAPTAINS_Ant</persName>
+          </person>
+          <person xml:id="Ventidius_Ant">
+            <persName>Ventidius</persName>
+          </person>
+          <person xml:id="Silius_Ant">
+            <persName>Silius</persName>
+          </person>
+          <person xml:id="Eros_Ant">
+            <persName>Eros</persName>
+          </person>
+          <person xml:id="Canidius_Ant">
+            <persName>Canidius</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.3_Ant">
+            <persName>MESSENGERS.X.3_Ant</persName>
+          </person>
+          <person xml:id="SOLDIERS.ANTONY.X.1_Ant">
+            <persName>SOLDIERS.ANTONY.X.1_Ant</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.4_Ant">
+            <persName>MESSENGERS.X.4_Ant</persName>
+          </person>
+          <person xml:id="Taurus_Ant">
+            <persName>Taurus</persName>
+          </person>
+          <person xml:id="Scarus_Ant">
+            <persName>Scarus</persName>
+          </person>
+          <person xml:id="ATTENDANTS.ANTONY_Ant">
+            <persName>ATTENDANTS.ANTONY_Ant</persName>
+          </person>
+          <person xml:id="Dolabella_Ant">
+            <persName>Dolabella</persName>
+          </person>
+          <person xml:id="Ambassador_Ant">
+            <persName>A Schoolmaster Ambassador</persName>
+            <persName>A Schoolmaster Ambassador</persName>
+          </person>
+          <person xml:id="Thidias_Ant">
+            <persName>Thidias</persName>
+          </person>
+          <person xml:id="SERVANTS.X.1_Ant">
+            <persName>SERVANTS.X.1_Ant</persName>
+          </person>
+          <person xml:id="SERVANTS.X.2_Ant">
+            <persName>SERVANTS.X.2_Ant</persName>
+          </person>
+          <person xml:id="SERVANTS_Ant">
+            <persName>Servants</persName>
+          </person>
+          <person xml:id="SOLDIERS.ANTONY.0.1_Ant">
+            <persName>SOLDIERS.ANTONY.0.1_Ant</persName>
+          </person>
+          <person xml:id="SOLDIERS.ANTONY.0.2_Ant">
+            <persName>SOLDIERS.ANTONY.0.2_Ant</persName>
+          </person>
+          <person xml:id="SOLDIERS.ANTONY.0.3_Ant">
+            <persName>SOLDIERS.ANTONY.0.3_Ant</persName>
+          </person>
+          <person xml:id="SOLDIERS.ANTONY.0.4_Ant">
+            <persName>SOLDIERS.ANTONY.0.4_Ant</persName>
+          </person>
+          <person xml:id="SOLDIERS.ANTONY_Ant">
+            <persName>SOLDIERS.ANTONY_Ant</persName>
+          </person>
+          <person xml:id="SOLDIERS.ANTONY.X.2_Ant">
+            <persName>SOLDIERS.ANTONY.X.2_Ant</persName>
+          </person>
+          <person xml:id="CAPTAINS.0.1_Ant">
+            <persName>A Captain</persName>
+          </person>
+          <person xml:id="SOLDIERS.ANTONY.X.3_Ant">
+            <persName>SOLDIERS.ANTONY.X.3_Ant</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.5_Ant">
+            <persName>MESSENGERS.X.5_Ant</persName>
+          </person>
+          <person xml:id="SOLDIERS.CAESAR.X.1_Ant">
+            <persName>SOLDIERS.CAESAR.X.1_Ant</persName>
+          </person>
+          <person xml:id="WATCHMEN.Sentry_Ant">
+            <persName>WATCHMEN.Sentry_Ant</persName>
+          </person>
+          <person xml:id="WATCHMEN.1_Ant">
+            <persName>WATCHMEN.1_Ant</persName>
+          </person>
+          <person xml:id="WATCHMEN.2_Ant">
+            <persName>WATCHMEN.2_Ant</persName>
+          </person>
+          <person xml:id="GUARDS.0.1_Ant">
+            <persName>GUARDS.0.1_Ant</persName>
+          </person>
+          <person xml:id="GUARDS.0.2_Ant">
+            <persName>GUARDS.0.2_Ant</persName>
+          </person>
+          <person xml:id="GUARDS_Ant">
+            <persName>Guardsmen</persName>
+          </person>
+          <person xml:id="GUARDS.Dercetus_Ant">
+            <persName>Dercetus</persName>
+          </person>
+          <person xml:id="GUARDS.0.3_Ant">
+            <persName>GUARDS.0.3_Ant</persName>
+          </person>
+          <person xml:id="Diomedes_Ant">
+            <persName>Diomedes</persName>
+          </person>
+          <person xml:id="LADIES_Ant">
+            <persName>LADIES_Ant</persName>
+          </person>
+          <person xml:id="Egyptian_Ant">
+            <persName>An Egyptian</persName>
+          </person>
+          <person xml:id="Proculeius_Ant">
+            <persName>Proculeius</persName>
+          </person>
+          <person xml:id="Gallus_Ant">
+            <persName>Gallus</persName>
+          </person>
+          <person xml:id="ATTENDANTS.CAESAR_Ant">
+            <persName>ATTENDANTS.CAESAR_Ant</persName>
+          </person>
+          <person xml:id="Seleucus_Ant">
+            <persName>Seleucus</persName>
+          </person>
+          <person xml:id="GUARDS.CAESAR.1_Ant">
+            <persName>GUARDS.CAESAR.1_Ant</persName>
+          </person>
+          <person xml:id="Countryman_Ant">
+            <persName>A Countryman</persName>
+          </person>
+          <person xml:id="GUARDS.CAESAR.0.1_Ant">
+            <persName>GUARDS.CAESAR.0.1_Ant</persName>
+          </person>
+          <person xml:id="GUARDS.CAESAR.0.2_Ant">
+            <persName>GUARDS.CAESAR.0.2_Ant</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/as-you-like-it.xml
+++ b/tei/as-you-like-it.xml
@@ -88,88 +88,88 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Orlando_AYL">
+          <person xml:id="Orlando_AYL" sex="MALE">
             <persName>Orlando</persName>
           </person>
-          <person xml:id="Adam_AYL">
+          <person xml:id="Adam_AYL" sex="MALE">
             <persName>Adam</persName>
           </person>
-          <person xml:id="Oliver_AYL">
+          <person xml:id="Oliver_AYL" sex="MALE">
             <persName>Oliver</persName>
           </person>
-          <person xml:id="Dennis_AYL">
+          <person xml:id="Dennis_AYL" sex="MALE">
             <persName>Dennis</persName>
           </person>
-          <person xml:id="Charles_AYL">
+          <person xml:id="Charles_AYL" sex="MALE">
             <persName>Charles</persName>
           </person>
-          <person xml:id="Celia_AYL">
+          <person xml:id="Celia_AYL" sex="FEMALE">
             <persName>Celia</persName>
           </person>
-          <person xml:id="Rosalind_AYL">
+          <person xml:id="Rosalind_AYL" sex="FEMALE">
             <persName>Rosalind</persName>
           </person>
-          <person xml:id="Touchstone_AYL">
+          <person xml:id="Touchstone_AYL" sex="MALE">
             <persName>Touchstone</persName>
           </person>
-          <person xml:id="LORDS.FREDERICK.LeBeau_AYL">
+          <person xml:id="LORDS.FREDERICK.LeBeau_AYL" sex="MALE">
             <persName>Le Beau</persName>
           </person>
-          <person xml:id="DukeFrederick_AYL">
+          <person xml:id="DukeFrederick_AYL" sex="MALE">
             <persName>Duke Frederick</persName>
           </person>
-          <person xml:id="DukeSenior_AYL">
+          <person xml:id="DukeSenior_AYL" sex="MALE">
             <persName>Duke Senior</persName>
           </person>
-          <person xml:id="LORDS.SENIOR.Amiens_AYL">
+          <person xml:id="LORDS.SENIOR.Amiens_AYL" sex="MALE">
             <persName>Amiens</persName>
           </person>
-          <person xml:id="LORDS.SENIOR.0.1_AYL">
+          <person xml:id="LORDS.SENIOR.0.1_AYL" sex="MALE">
             <persName>First Lord</persName>
           </person>
-          <person xml:id="LORDS.SENIOR.0.2_AYL">
+          <person xml:id="LORDS.SENIOR.0.2_AYL" sex="MALE">
             <persName>Second Lord</persName>
           </person>
-          <person xml:id="LORDS.FREDERICK.0.1_AYL">
+          <person xml:id="LORDS.FREDERICK.0.1_AYL" sex="MALE">
             <persName>First Lord</persName>
           </person>
-          <person xml:id="LORDS.FREDERICK.0.2_AYL">
+          <person xml:id="LORDS.FREDERICK.0.2_AYL" sex="MALE">
             <persName>Second Lord</persName>
           </person>
-          <person xml:id="Corin_AYL">
+          <person xml:id="Corin_AYL" sex="MALE">
             <persName>Corin</persName>
           </person>
-          <person xml:id="Silvius_AYL">
+          <person xml:id="Silvius_AYL" sex="MALE">
             <persName>Silvius</persName>
           </person>
-          <person xml:id="Jaques_AYL">
+          <person xml:id="Jaques_AYL" sex="MALE">
             <persName>Jaques</persName>
           </person>
-          <person xml:id="LORDS.SENIOR_AYL">
-            <persName>Lords, Attendants, Musicians</persName>
-          </person>
-          <person xml:id="Audrey_AYL">
+          <personGrp xml:id="LORDS.SENIOR_AYL" sex="UNKNOWN">
+            <name>Lords, Attendants, Musicians</name>
+          </personGrp>
+          <person xml:id="Audrey_AYL" sex="FEMALE">
             <persName>Audrey</persName>
           </person>
-          <person xml:id="OliverMartext_AYL">
+          <person xml:id="OliverMartext_AYL" sex="MALE">
             <persName>Sir Oliver Martext</persName>
           </person>
-          <person xml:id="Phoebe_AYL">
+          <person xml:id="Phoebe_AYL" sex="FEMALE">
             <persName>Phoebe</persName>
           </person>
-          <person xml:id="William_AYL">
+          <person xml:id="William_AYL" sex="MALE">
             <persName>William</persName>
           </person>
-          <person xml:id="SERVANTS.1_AYL">
+          <person xml:id="SERVANTS.1_AYL" sex="UNKNOWN">
             <persName>First Page</persName>
           </person>
-          <person xml:id="SERVANTS.2_AYL">
+          <person xml:id="SERVANTS.2_AYL" sex="UNKNOWN">
             <persName>Second Page</persName>
           </person>
-          <person xml:id="Hymen_AYL">
+          <person xml:id="Hymen_AYL" ana="http://www.wikidata.org/entity/Q506770">
             <persName>Hymen</persName>
           </person>
-          <person xml:id="SecondBrother_AYL">
+          <person xml:id="SecondBrother_AYL" sex="MALE">
             <persName>Second Brother</persName>
           </person>
         </listPerson>

--- a/tei/as-you-like-it.xml
+++ b/tei/as-you-like-it.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,95 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Orlando_AYL"><persName>Orlando</persName></person><person xml:id="Adam_AYL"><persName>Adam</persName></person><person xml:id="Oliver_AYL"><persName>Oliver</persName></person><person xml:id="Dennis_AYL"><persName>Dennis</persName></person><person xml:id="Charles_AYL"><persName>Charles</persName></person><person xml:id="Celia_AYL"><persName>Celia</persName></person><person xml:id="Rosalind_AYL"><persName>Rosalind</persName></person><person xml:id="Touchstone_AYL"><persName>Touchstone</persName></person><person xml:id="LORDS.FREDERICK.LeBeau_AYL"><persName>Le Beau</persName></person><person xml:id="DukeFrederick_AYL"><persName>Duke Frederick</persName></person><person xml:id="DukeSenior_AYL"><persName>Duke Senior</persName></person><person xml:id="LORDS.SENIOR.Amiens_AYL"><persName>Amiens</persName></person><person xml:id="LORDS.SENIOR.0.1_AYL"><persName>First Lord</persName></person><person xml:id="LORDS.SENIOR.0.2_AYL"><persName>Second Lord</persName></person><person xml:id="LORDS.FREDERICK.0.1_AYL"><persName>First Lord</persName></person><person xml:id="LORDS.FREDERICK.0.2_AYL"><persName>Second Lord</persName></person><person xml:id="Corin_AYL"><persName>Corin</persName></person><person xml:id="Silvius_AYL"><persName>Silvius</persName></person><person xml:id="Jaques_AYL"><persName>Jaques</persName></person><person xml:id="LORDS.SENIOR_AYL"><persName>Lords, Attendants, Musicians</persName></person><person xml:id="Audrey_AYL"><persName>Audrey</persName></person><person xml:id="OliverMartext_AYL"><persName>Sir Oliver Martext</persName></person><person xml:id="Phoebe_AYL"><persName>Phoebe</persName></person><person xml:id="William_AYL"><persName>William</persName></person><person xml:id="SERVANTS.1_AYL"><persName>First Page</persName></person><person xml:id="SERVANTS.2_AYL"><persName>Second Page</persName></person><person xml:id="Hymen_AYL"><persName>Hymen</persName></person><person xml:id="SecondBrother_AYL"><persName>Second Brother</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Orlando_AYL">
+            <persName>Orlando</persName>
+          </person>
+          <person xml:id="Adam_AYL">
+            <persName>Adam</persName>
+          </person>
+          <person xml:id="Oliver_AYL">
+            <persName>Oliver</persName>
+          </person>
+          <person xml:id="Dennis_AYL">
+            <persName>Dennis</persName>
+          </person>
+          <person xml:id="Charles_AYL">
+            <persName>Charles</persName>
+          </person>
+          <person xml:id="Celia_AYL">
+            <persName>Celia</persName>
+          </person>
+          <person xml:id="Rosalind_AYL">
+            <persName>Rosalind</persName>
+          </person>
+          <person xml:id="Touchstone_AYL">
+            <persName>Touchstone</persName>
+          </person>
+          <person xml:id="LORDS.FREDERICK.LeBeau_AYL">
+            <persName>Le Beau</persName>
+          </person>
+          <person xml:id="DukeFrederick_AYL">
+            <persName>Duke Frederick</persName>
+          </person>
+          <person xml:id="DukeSenior_AYL">
+            <persName>Duke Senior</persName>
+          </person>
+          <person xml:id="LORDS.SENIOR.Amiens_AYL">
+            <persName>Amiens</persName>
+          </person>
+          <person xml:id="LORDS.SENIOR.0.1_AYL">
+            <persName>First Lord</persName>
+          </person>
+          <person xml:id="LORDS.SENIOR.0.2_AYL">
+            <persName>Second Lord</persName>
+          </person>
+          <person xml:id="LORDS.FREDERICK.0.1_AYL">
+            <persName>First Lord</persName>
+          </person>
+          <person xml:id="LORDS.FREDERICK.0.2_AYL">
+            <persName>Second Lord</persName>
+          </person>
+          <person xml:id="Corin_AYL">
+            <persName>Corin</persName>
+          </person>
+          <person xml:id="Silvius_AYL">
+            <persName>Silvius</persName>
+          </person>
+          <person xml:id="Jaques_AYL">
+            <persName>Jaques</persName>
+          </person>
+          <person xml:id="LORDS.SENIOR_AYL">
+            <persName>Lords, Attendants, Musicians</persName>
+          </person>
+          <person xml:id="Audrey_AYL">
+            <persName>Audrey</persName>
+          </person>
+          <person xml:id="OliverMartext_AYL">
+            <persName>Sir Oliver Martext</persName>
+          </person>
+          <person xml:id="Phoebe_AYL">
+            <persName>Phoebe</persName>
+          </person>
+          <person xml:id="William_AYL">
+            <persName>William</persName>
+          </person>
+          <person xml:id="SERVANTS.1_AYL">
+            <persName>First Page</persName>
+          </person>
+          <person xml:id="SERVANTS.2_AYL">
+            <persName>Second Page</persName>
+          </person>
+          <person xml:id="Hymen_AYL">
+            <persName>Hymen</persName>
+          </person>
+          <person xml:id="SecondBrother_AYL">
+            <persName>Second Brother</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/coriolanus.xml
+++ b/tei/coriolanus.xml
@@ -88,212 +88,212 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="CITIZENS.ROMAN.0.1_Cor">
+          <person xml:id="CITIZENS.ROMAN.0.1_Cor" sex="MALE">
             <persName>CITIZENS.ROMAN.0.1_Cor</persName>
           </person>
-          <person xml:id="CITIZENS.ROMAN_Cor">
-            <persName>Citizens Plebeians</persName>
-            <persName>Citizens Plebeians</persName>
-          </person>
-          <person xml:id="CITIZENS.ROMAN.0.2_Cor">
+          <personGrp xml:id="CITIZENS.ROMAN_Cor" sex="UNKNOWN">
+            <name>Citizens Plebeians</name>
+            <name>Citizens Plebeians</name>
+          </personGrp>
+          <person xml:id="CITIZENS.ROMAN.0.2_Cor" sex="MALE">
             <persName>CITIZENS.ROMAN.0.2_Cor</persName>
           </person>
-          <person xml:id="Menenius_Cor">
+          <person xml:id="Menenius_Cor" ana="http://www.wikidata.org/entity/Q396971">
             <persName>Menenius</persName>
           </person>
-          <person xml:id="Coriolanus_Cor">
+          <person xml:id="Coriolanus_Cor" ana="http://www.wikidata.org/entity/Q570532">
             <persName>Martius Coriolanus</persName>
             <persName>Martius Coriolanus</persName>
           </person>
-          <person xml:id="MESSENGERS.X.1_Cor">
+          <person xml:id="MESSENGERS.X.1_Cor" sex="MALE">
             <persName>MESSENGERS.X.1_Cor</persName>
           </person>
-          <person xml:id="SENATORS.ROMAN.0.1_Cor">
+          <person xml:id="SENATORS.ROMAN.0.1_Cor" sex="MALE">
             <persName>SENATORS.ROMAN.0.1_Cor</persName>
           </person>
-          <person xml:id="Cominius_Cor">
+          <person xml:id="Cominius_Cor" ana="http://www.wikidata.org/entity/Q1236578">
             <persName>Cominius</persName>
           </person>
-          <person xml:id="Lartius_Cor">
+          <person xml:id="Lartius_Cor" ana="http://www.wikidata.org/entity/Q529867">
             <persName>Lartius</persName>
           </person>
-          <person xml:id="TRIBUNES.Sicinius_Cor">
+          <person xml:id="TRIBUNES.Sicinius_Cor" ana="http://www.wikidata.org/entity/Q1235782">
             <persName>Sicinius</persName>
           </person>
-          <person xml:id="TRIBUNES.Brutus_Cor">
+          <person xml:id="TRIBUNES.Brutus_Cor" ana="http://www.wikidata.org/entity/Q223440">
             <persName>Brutus</persName>
           </person>
-          <person xml:id="SENATORS.VOLSCIAN.0.1_Cor">
+          <person xml:id="SENATORS.VOLSCIAN.0.1_Cor" sex="MALE">
             <persName>SENATORS.VOLSCIAN.0.1_Cor</persName>
           </person>
-          <person xml:id="Aufidius_Cor">
+          <person xml:id="Aufidius_Cor" ana="http://www.wikidata.org/entity/Q2870125">
             <persName>Aufidius</persName>
           </person>
-          <person xml:id="SENATORS.VOLSCIAN.0.2_Cor">
+          <person xml:id="SENATORS.VOLSCIAN.0.2_Cor" sex="MALE">
             <persName>SENATORS.VOLSCIAN.0.2_Cor</persName>
           </person>
-          <person xml:id="SENATORS.VOLSCIAN_Cor">
+          <person xml:id="SENATORS.VOLSCIAN_Cor" sex="MALE">
             <persName>SENATORS.VOLSCIAN_Cor</persName>
           </person>
-          <person xml:id="Volumnia_Cor">
+          <person xml:id="Volumnia_Cor" sex="FEMALE">
             <persName>Volumnia</persName>
           </person>
-          <person xml:id="Virgilia_Cor">
+          <person xml:id="Virgilia_Cor" ana="http://www.wikidata.org/entity/Q543615">
             <persName>Virgilia</persName>
           </person>
-          <person xml:id="Gentlewoman_Cor">
+          <person xml:id="Gentlewoman_Cor" sex="FEMALE">
             <persName>Gentlewoman</persName>
           </person>
-          <person xml:id="Valeria_Cor">
+          <person xml:id="Valeria_Cor" sex="FEMALE">
             <persName>Valeria</persName>
           </person>
-          <person xml:id="MESSENGERS.X.2_Cor">
+          <person xml:id="MESSENGERS.X.2_Cor" sex="MALE">
             <persName>MESSENGERS.X.2_Cor</persName>
           </person>
-          <person xml:id="SOLDIERS.ROMAN.0.1_Cor">
+          <person xml:id="SOLDIERS.ROMAN.0.1_Cor" sex="MALE">
             <persName>SOLDIERS.ROMAN.0.1_Cor</persName>
           </person>
-          <person xml:id="SOLDIERS.ROMAN.0.2_Cor">
+          <person xml:id="SOLDIERS.ROMAN.0.2_Cor" sex="MALE">
             <persName>SOLDIERS.ROMAN.0.2_Cor</persName>
           </person>
-          <person xml:id="SOLDIERS.ROMAN_Cor">
-            <persName>Soldiers</persName>
-          </person>
-          <person xml:id="SOLDIERS.ROMAN.0.3_Cor">
+          <personGrp xml:id="SOLDIERS.ROMAN_Cor" sex="UNKNOWN">
+            <name>Soldiers</name>
+          </personGrp>
+          <person xml:id="SOLDIERS.ROMAN.0.3_Cor" sex="MALE">
             <persName>SOLDIERS.ROMAN.0.3_Cor</persName>
           </person>
-          <person xml:id="MESSENGERS.X.3_Cor">
+          <person xml:id="MESSENGERS.X.3_Cor" sex="MALE">
             <persName>MESSENGERS.X.3_Cor</persName>
           </person>
-          <person xml:id="SOLDIERS.ROMAN.Lieutenant_Cor">
+          <person xml:id="SOLDIERS.ROMAN.Lieutenant_Cor" sex="MALE">
             <persName>Lieutenant</persName>
           </person>
-          <person xml:id="SOLDIERS.VOLSCIAN.0.1_Cor">
+          <person xml:id="SOLDIERS.VOLSCIAN.0.1_Cor" sex="MALE">
             <persName>SOLDIERS.VOLSCIAN.0.1_Cor</persName>
           </person>
-          <person xml:id="Herald_Cor">
+          <person xml:id="Herald_Cor" sex="MALE">
             <persName>Herald</persName>
           </person>
-          <person xml:id="MESSENGERS.X.4_Cor">
+          <person xml:id="MESSENGERS.X.4_Cor" sex="MALE">
             <persName>MESSENGERS.X.4_Cor</persName>
           </person>
-          <person xml:id="OFFICERS.1_Cor">
+          <person xml:id="OFFICERS.1_Cor" sex="MALE">
             <persName>OFFICERS.1_Cor</persName>
           </person>
-          <person xml:id="OFFICERS.2_Cor">
+          <person xml:id="OFFICERS.2_Cor" sex="MALE">
             <persName>OFFICERS.2_Cor</persName>
           </person>
-          <person xml:id="SENATORS.ROMAN_Cor">
-            <persName>Senators Patricians Nobles</persName>
-            <persName>Senators Patricians Nobles</persName>
-            <persName>Senators Patricians Nobles</persName>
-          </person>
-          <person xml:id="CITIZENS.ROMAN.1_Cor">
+          <personGrp xml:id="SENATORS.ROMAN_Cor" sex="UNKNOWN">
+            <name>Senators Patricians Nobles</name>
+            <name>Senators Patricians Nobles</name>
+            <name>Senators Patricians Nobles</name>
+          </personGrp>
+          <person xml:id="CITIZENS.ROMAN.1_Cor" sex="MALE">
             <persName>CITIZENS.ROMAN.1_Cor</persName>
           </person>
-          <person xml:id="CITIZENS.ROMAN.2_Cor">
+          <person xml:id="CITIZENS.ROMAN.2_Cor" sex="MALE">
             <persName>CITIZENS.ROMAN.2_Cor</persName>
           </person>
-          <person xml:id="CITIZENS.ROMAN.3_Cor">
+          <person xml:id="CITIZENS.ROMAN.3_Cor" sex="MALE">
             <persName>CITIZENS.ROMAN.3_Cor</persName>
           </person>
-          <person xml:id="CITIZENS.ROMAN.4_Cor">
+          <person xml:id="CITIZENS.ROMAN.4_Cor" sex="MALE">
             <persName>CITIZENS.ROMAN.4_Cor</persName>
           </person>
-          <person xml:id="CITIZENS.ROMAN.5_Cor">
+          <person xml:id="CITIZENS.ROMAN.5_Cor" sex="MALE">
             <persName>CITIZENS.ROMAN.5_Cor</persName>
           </person>
-          <person xml:id="CITIZENS.ROMAN.6_Cor">
+          <person xml:id="CITIZENS.ROMAN.6_Cor" sex="MALE">
             <persName>CITIZENS.ROMAN.6_Cor</persName>
           </person>
-          <person xml:id="CITIZENS.ROMAN.7_Cor">
+          <person xml:id="CITIZENS.ROMAN.7_Cor" sex="MALE">
             <persName>CITIZENS.ROMAN.7_Cor</persName>
           </person>
-          <person xml:id="CITIZENS.ROMAN.8_Cor">
+          <person xml:id="CITIZENS.ROMAN.8_Cor" sex="MALE">
             <persName>CITIZENS.ROMAN.8_Cor</persName>
           </person>
-          <person xml:id="SENATORS.ROMAN.0.2_Cor">
+          <person xml:id="SENATORS.ROMAN.0.2_Cor" sex="MALE">
             <persName>SENATORS.ROMAN.0.2_Cor</persName>
           </person>
-          <person xml:id="AEDILES_Cor">
-            <persName>Aediles</persName>
-          </person>
-          <person xml:id="NOBLES.0.1_Cor">
-            <persName>Roman Lords, Gentry, Captains, Lictors, Trumpeters, Drummers, Musicians, Attendants, and Usher</persName>
-          </person>
-          <person xml:id="AEDILES.X.2_Cor">
+          <personGrp xml:id="AEDILES_Cor" sex="UNKNOWN">
+            <name>Aediles</name>
+          </personGrp>
+          <personGrp xml:id="NOBLES.0.1_Cor" sex="UNKNOWN">
+            <name>Roman Lords, Gentry, Captains, Lictors, Trumpeters, Drummers, Musicians, Attendants, and Usher</name>
+          </personGrp>
+          <person xml:id="AEDILES.X.2_Cor" sex="MALE">
             <persName>AEDILES.X.2_Cor</persName>
           </person>
-          <person xml:id="Nicanor_Cor">
+          <person xml:id="Nicanor_Cor" sex="MALE">
             <persName>Roman</persName>
           </person>
-          <person xml:id="Adrian_Cor">
+          <person xml:id="Adrian_Cor" sex="MALE">
             <persName>Volscian</persName>
           </person>
-          <person xml:id="CITIZENS.ANTIUM.1_Cor">
+          <person xml:id="CITIZENS.ANTIUM.1_Cor" sex="MALE">
             <persName>Citizen</persName>
           </person>
-          <person xml:id="SERVANTS.1_Cor">
+          <person xml:id="SERVANTS.1_Cor" sex="MALE">
             <persName>SERVANTS.1_Cor</persName>
           </person>
-          <person xml:id="SERVANTS.2_Cor">
+          <person xml:id="SERVANTS.2_Cor" sex="MALE">
             <persName>SERVANTS.2_Cor</persName>
           </person>
-          <person xml:id="SERVANTS.3_Cor">
+          <person xml:id="SERVANTS.3_Cor" sex="MALE">
             <persName>SERVANTS.3_Cor</persName>
           </person>
-          <person xml:id="AEDILES.X.3_Cor">
+          <person xml:id="AEDILES.X.3_Cor" sex="MALE">
             <persName>AEDILES.X.3_Cor</persName>
           </person>
-          <person xml:id="MESSENGERS.TRIBUNES.1_Cor">
+          <person xml:id="MESSENGERS.TRIBUNES.1_Cor" sex="MALE">
             <persName>MESSENGERS.TRIBUNES.1_Cor</persName>
           </person>
-          <person xml:id="MESSENGERS.TRIBUNES.2_Cor">
+          <person xml:id="MESSENGERS.TRIBUNES.2_Cor" sex="MALE">
             <persName>MESSENGERS.TRIBUNES.2_Cor</persName>
           </person>
-          <person xml:id="CITIZENS.ROMAN.0.3_Cor">
+          <person xml:id="CITIZENS.ROMAN.0.3_Cor" sex="MALE">
             <persName>CITIZENS.ROMAN.0.3_Cor</persName>
           </person>
-          <person xml:id="SOLDIERS.VOLSCIAN.Lieutenant_Cor">
+          <person xml:id="SOLDIERS.VOLSCIAN.Lieutenant_Cor" sex="MALE">
             <persName>Lieutenant</persName>
           </person>
-          <person xml:id="WATCHMEN.1_Cor">
+          <person xml:id="WATCHMEN.1_Cor" sex="MALE">
             <persName>WATCHMEN.1_Cor</persName>
           </person>
-          <person xml:id="WATCHMEN.2_Cor">
+          <person xml:id="WATCHMEN.2_Cor" sex="MALE">
             <persName>WATCHMEN.2_Cor</persName>
           </person>
-          <person xml:id="YoungMartius_Cor">
+          <person xml:id="YoungMartius_Cor" sex="MALE">
             <persName>Young Martius</persName>
           </person>
-          <person xml:id="CONSPIRATORS.0.1_Cor">
+          <person xml:id="CONSPIRATORS.0.1_Cor" sex="MALE">
             <persName>CONSPIRATORS.0.1_Cor</persName>
           </person>
-          <person xml:id="CONSPIRATORS.0.2_Cor">
+          <person xml:id="CONSPIRATORS.0.2_Cor" sex="MALE">
             <persName>CONSPIRATORS.0.2_Cor</persName>
           </person>
-          <person xml:id="CONSPIRATORS.0.3_Cor">
+          <person xml:id="CONSPIRATORS.0.3_Cor" sex="MALE">
             <persName>CONSPIRATORS.0.3_Cor</persName>
           </person>
-          <person xml:id="LORDS.VOLSCIAN_Cor">
-            <persName>Senators Lords</persName>
-            <persName>Senators Lords</persName>
-          </person>
-          <person xml:id="LORDS.VOLSCIAN.0.1_Cor">
-            <persName>Roman Lords, Gentry, Captains, Lictors, Trumpeters, Drummers, Musicians, Attendants, and Usher</persName>
-          </person>
-          <person xml:id="CONSPIRATORS_Cor">
-            <persName>Conspirators</persName>
-          </person>
-          <person xml:id="CITIZENS.VOLSCIAN_Cor">
-            <persName>People</persName>
-          </person>
-          <person xml:id="LORDS.VOLSCIAN.0.2_Cor">
-            <persName>Roman Lords, Gentry, Captains, Lictors, Trumpeters, Drummers, Musicians, Attendants, and Usher</persName>
-          </person>
-          <person xml:id="LORDS.VOLSCIAN.0.3_Cor">
-            <persName>Roman Lords, Gentry, Captains, Lictors, Trumpeters, Drummers, Musicians, Attendants, and Usher</persName>
-          </person>
+          <personGrp xml:id="LORDS.VOLSCIAN_Cor" sex="UNKNOWN">
+            <name>Senators Lords</name>
+            <name>Senators Lords</name>
+          </personGrp>
+          <personGrp xml:id="LORDS.VOLSCIAN.0.1_Cor" sex="UNKNOWN">
+            <name>Roman Lords, Gentry, Captains, Lictors, Trumpeters, Drummers, Musicians, Attendants, and Usher</name>
+          </personGrp>
+          <personGrp xml:id="CONSPIRATORS_Cor" sex="UNKNOWN">
+            <name>Conspirators</name>
+          </personGrp>
+          <personGrp xml:id="CITIZENS.VOLSCIAN_Cor" sex="UNKNOWN">
+            <name>People</name>
+          </personGrp>
+          <personGrp xml:id="LORDS.VOLSCIAN.0.2_Cor" sex="UNKNOWN">
+            <name>Roman Lords, Gentry, Captains, Lictors, Trumpeters, Drummers, Musicians, Attendants, and Usher</name>
+          </personGrp>
+          <personGrp xml:id="LORDS.VOLSCIAN.0.3_Cor" sex="UNKNOWN">
+            <name>Roman Lords, Gentry, Captains, Lictors, Trumpeters, Drummers, Musicians, Attendants, and Usher</name>
+          </personGrp>
         </listPerson>
       </particDesc>
     </profileDesc>

--- a/tei/coriolanus.xml
+++ b/tei/coriolanus.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,217 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="CITIZENS.ROMAN.0.1_Cor"><persName>CITIZENS.ROMAN.0.1_Cor</persName></person><person xml:id="CITIZENS.ROMAN_Cor"><persName>Citizens Plebeians</persName><persName>Citizens Plebeians</persName></person><person xml:id="CITIZENS.ROMAN.0.2_Cor"><persName>CITIZENS.ROMAN.0.2_Cor</persName></person><person xml:id="Menenius_Cor"><persName>Menenius</persName></person><person xml:id="Coriolanus_Cor"><persName>Martius Coriolanus</persName><persName>Martius Coriolanus</persName></person><person xml:id="MESSENGERS.X.1_Cor"><persName>MESSENGERS.X.1_Cor</persName></person><person xml:id="SENATORS.ROMAN.0.1_Cor"><persName>SENATORS.ROMAN.0.1_Cor</persName></person><person xml:id="Cominius_Cor"><persName>Cominius</persName></person><person xml:id="Lartius_Cor"><persName>Lartius</persName></person><person xml:id="TRIBUNES.Sicinius_Cor"><persName>Sicinius</persName></person><person xml:id="TRIBUNES.Brutus_Cor"><persName>Brutus</persName></person><person xml:id="SENATORS.VOLSCIAN.0.1_Cor"><persName>SENATORS.VOLSCIAN.0.1_Cor</persName></person><person xml:id="Aufidius_Cor"><persName>Aufidius</persName></person><person xml:id="SENATORS.VOLSCIAN.0.2_Cor"><persName>SENATORS.VOLSCIAN.0.2_Cor</persName></person><person xml:id="SENATORS.VOLSCIAN_Cor"><persName>SENATORS.VOLSCIAN_Cor</persName></person><person xml:id="Volumnia_Cor"><persName>Volumnia</persName></person><person xml:id="Virgilia_Cor"><persName>Virgilia</persName></person><person xml:id="Gentlewoman_Cor"><persName>Gentlewoman</persName></person><person xml:id="Valeria_Cor"><persName>Valeria</persName></person><person xml:id="MESSENGERS.X.2_Cor"><persName>MESSENGERS.X.2_Cor</persName></person><person xml:id="SOLDIERS.ROMAN.0.1_Cor"><persName>SOLDIERS.ROMAN.0.1_Cor</persName></person><person xml:id="SOLDIERS.ROMAN.0.2_Cor"><persName>SOLDIERS.ROMAN.0.2_Cor</persName></person><person xml:id="SOLDIERS.ROMAN_Cor"><persName>Soldiers</persName></person><person xml:id="SOLDIERS.ROMAN.0.3_Cor"><persName>SOLDIERS.ROMAN.0.3_Cor</persName></person><person xml:id="MESSENGERS.X.3_Cor"><persName>MESSENGERS.X.3_Cor</persName></person><person xml:id="SOLDIERS.ROMAN.Lieutenant_Cor"><persName>Lieutenant</persName></person><person xml:id="SOLDIERS.VOLSCIAN.0.1_Cor"><persName>SOLDIERS.VOLSCIAN.0.1_Cor</persName></person><person xml:id="Herald_Cor"><persName>Herald</persName></person><person xml:id="MESSENGERS.X.4_Cor"><persName>MESSENGERS.X.4_Cor</persName></person><person xml:id="OFFICERS.1_Cor"><persName>OFFICERS.1_Cor</persName></person><person xml:id="OFFICERS.2_Cor"><persName>OFFICERS.2_Cor</persName></person><person xml:id="SENATORS.ROMAN_Cor"><persName>Senators Patricians Nobles</persName><persName>Senators Patricians Nobles</persName><persName>Senators Patricians Nobles</persName></person><person xml:id="CITIZENS.ROMAN.1_Cor"><persName>CITIZENS.ROMAN.1_Cor</persName></person><person xml:id="CITIZENS.ROMAN.2_Cor"><persName>CITIZENS.ROMAN.2_Cor</persName></person><person xml:id="CITIZENS.ROMAN.3_Cor"><persName>CITIZENS.ROMAN.3_Cor</persName></person><person xml:id="CITIZENS.ROMAN.4_Cor"><persName>CITIZENS.ROMAN.4_Cor</persName></person><person xml:id="CITIZENS.ROMAN.5_Cor"><persName>CITIZENS.ROMAN.5_Cor</persName></person><person xml:id="CITIZENS.ROMAN.6_Cor"><persName>CITIZENS.ROMAN.6_Cor</persName></person><person xml:id="CITIZENS.ROMAN.7_Cor"><persName>CITIZENS.ROMAN.7_Cor</persName></person><person xml:id="CITIZENS.ROMAN.8_Cor"><persName>CITIZENS.ROMAN.8_Cor</persName></person><person xml:id="SENATORS.ROMAN.0.2_Cor"><persName>SENATORS.ROMAN.0.2_Cor</persName></person><person xml:id="AEDILES_Cor"><persName>Aediles</persName></person><person xml:id="NOBLES.0.1_Cor"><persName>Roman Lords, Gentry, Captains, Lictors, Trumpeters, Drummers, Musicians, Attendants, and Usher</persName></person><person xml:id="AEDILES.X.2_Cor"><persName>AEDILES.X.2_Cor</persName></person><person xml:id="Nicanor_Cor"><persName>Roman</persName></person><person xml:id="Adrian_Cor"><persName>Volscian</persName></person><person xml:id="CITIZENS.ANTIUM.1_Cor"><persName>Citizen</persName></person><person xml:id="SERVANTS.1_Cor"><persName>SERVANTS.1_Cor</persName></person><person xml:id="SERVANTS.2_Cor"><persName>SERVANTS.2_Cor</persName></person><person xml:id="SERVANTS.3_Cor"><persName>SERVANTS.3_Cor</persName></person><person xml:id="AEDILES.X.3_Cor"><persName>AEDILES.X.3_Cor</persName></person><person xml:id="MESSENGERS.TRIBUNES.1_Cor"><persName>MESSENGERS.TRIBUNES.1_Cor</persName></person><person xml:id="MESSENGERS.TRIBUNES.2_Cor"><persName>MESSENGERS.TRIBUNES.2_Cor</persName></person><person xml:id="CITIZENS.ROMAN.0.3_Cor"><persName>CITIZENS.ROMAN.0.3_Cor</persName></person><person xml:id="SOLDIERS.VOLSCIAN.Lieutenant_Cor"><persName>Lieutenant</persName></person><person xml:id="WATCHMEN.1_Cor"><persName>WATCHMEN.1_Cor</persName></person><person xml:id="WATCHMEN.2_Cor"><persName>WATCHMEN.2_Cor</persName></person><person xml:id="YoungMartius_Cor"><persName>Young Martius</persName></person><person xml:id="CONSPIRATORS.0.1_Cor"><persName>CONSPIRATORS.0.1_Cor</persName></person><person xml:id="CONSPIRATORS.0.2_Cor"><persName>CONSPIRATORS.0.2_Cor</persName></person><person xml:id="CONSPIRATORS.0.3_Cor"><persName>CONSPIRATORS.0.3_Cor</persName></person><person xml:id="LORDS.VOLSCIAN_Cor"><persName>Senators Lords</persName><persName>Senators Lords</persName></person><person xml:id="LORDS.VOLSCIAN.0.1_Cor"><persName>Roman Lords, Gentry, Captains, Lictors, Trumpeters, Drummers, Musicians, Attendants, and Usher</persName></person><person xml:id="CONSPIRATORS_Cor"><persName>Conspirators</persName></person><person xml:id="CITIZENS.VOLSCIAN_Cor"><persName>People</persName></person><person xml:id="LORDS.VOLSCIAN.0.2_Cor"><persName>Roman Lords, Gentry, Captains, Lictors, Trumpeters, Drummers, Musicians, Attendants, and Usher</persName></person><person xml:id="LORDS.VOLSCIAN.0.3_Cor"><persName>Roman Lords, Gentry, Captains, Lictors, Trumpeters, Drummers, Musicians, Attendants, and Usher</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="CITIZENS.ROMAN.0.1_Cor">
+            <persName>CITIZENS.ROMAN.0.1_Cor</persName>
+          </person>
+          <person xml:id="CITIZENS.ROMAN_Cor">
+            <persName>Citizens Plebeians</persName>
+            <persName>Citizens Plebeians</persName>
+          </person>
+          <person xml:id="CITIZENS.ROMAN.0.2_Cor">
+            <persName>CITIZENS.ROMAN.0.2_Cor</persName>
+          </person>
+          <person xml:id="Menenius_Cor">
+            <persName>Menenius</persName>
+          </person>
+          <person xml:id="Coriolanus_Cor">
+            <persName>Martius Coriolanus</persName>
+            <persName>Martius Coriolanus</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.1_Cor">
+            <persName>MESSENGERS.X.1_Cor</persName>
+          </person>
+          <person xml:id="SENATORS.ROMAN.0.1_Cor">
+            <persName>SENATORS.ROMAN.0.1_Cor</persName>
+          </person>
+          <person xml:id="Cominius_Cor">
+            <persName>Cominius</persName>
+          </person>
+          <person xml:id="Lartius_Cor">
+            <persName>Lartius</persName>
+          </person>
+          <person xml:id="TRIBUNES.Sicinius_Cor">
+            <persName>Sicinius</persName>
+          </person>
+          <person xml:id="TRIBUNES.Brutus_Cor">
+            <persName>Brutus</persName>
+          </person>
+          <person xml:id="SENATORS.VOLSCIAN.0.1_Cor">
+            <persName>SENATORS.VOLSCIAN.0.1_Cor</persName>
+          </person>
+          <person xml:id="Aufidius_Cor">
+            <persName>Aufidius</persName>
+          </person>
+          <person xml:id="SENATORS.VOLSCIAN.0.2_Cor">
+            <persName>SENATORS.VOLSCIAN.0.2_Cor</persName>
+          </person>
+          <person xml:id="SENATORS.VOLSCIAN_Cor">
+            <persName>SENATORS.VOLSCIAN_Cor</persName>
+          </person>
+          <person xml:id="Volumnia_Cor">
+            <persName>Volumnia</persName>
+          </person>
+          <person xml:id="Virgilia_Cor">
+            <persName>Virgilia</persName>
+          </person>
+          <person xml:id="Gentlewoman_Cor">
+            <persName>Gentlewoman</persName>
+          </person>
+          <person xml:id="Valeria_Cor">
+            <persName>Valeria</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.2_Cor">
+            <persName>MESSENGERS.X.2_Cor</persName>
+          </person>
+          <person xml:id="SOLDIERS.ROMAN.0.1_Cor">
+            <persName>SOLDIERS.ROMAN.0.1_Cor</persName>
+          </person>
+          <person xml:id="SOLDIERS.ROMAN.0.2_Cor">
+            <persName>SOLDIERS.ROMAN.0.2_Cor</persName>
+          </person>
+          <person xml:id="SOLDIERS.ROMAN_Cor">
+            <persName>Soldiers</persName>
+          </person>
+          <person xml:id="SOLDIERS.ROMAN.0.3_Cor">
+            <persName>SOLDIERS.ROMAN.0.3_Cor</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.3_Cor">
+            <persName>MESSENGERS.X.3_Cor</persName>
+          </person>
+          <person xml:id="SOLDIERS.ROMAN.Lieutenant_Cor">
+            <persName>Lieutenant</persName>
+          </person>
+          <person xml:id="SOLDIERS.VOLSCIAN.0.1_Cor">
+            <persName>SOLDIERS.VOLSCIAN.0.1_Cor</persName>
+          </person>
+          <person xml:id="Herald_Cor">
+            <persName>Herald</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.4_Cor">
+            <persName>MESSENGERS.X.4_Cor</persName>
+          </person>
+          <person xml:id="OFFICERS.1_Cor">
+            <persName>OFFICERS.1_Cor</persName>
+          </person>
+          <person xml:id="OFFICERS.2_Cor">
+            <persName>OFFICERS.2_Cor</persName>
+          </person>
+          <person xml:id="SENATORS.ROMAN_Cor">
+            <persName>Senators Patricians Nobles</persName>
+            <persName>Senators Patricians Nobles</persName>
+            <persName>Senators Patricians Nobles</persName>
+          </person>
+          <person xml:id="CITIZENS.ROMAN.1_Cor">
+            <persName>CITIZENS.ROMAN.1_Cor</persName>
+          </person>
+          <person xml:id="CITIZENS.ROMAN.2_Cor">
+            <persName>CITIZENS.ROMAN.2_Cor</persName>
+          </person>
+          <person xml:id="CITIZENS.ROMAN.3_Cor">
+            <persName>CITIZENS.ROMAN.3_Cor</persName>
+          </person>
+          <person xml:id="CITIZENS.ROMAN.4_Cor">
+            <persName>CITIZENS.ROMAN.4_Cor</persName>
+          </person>
+          <person xml:id="CITIZENS.ROMAN.5_Cor">
+            <persName>CITIZENS.ROMAN.5_Cor</persName>
+          </person>
+          <person xml:id="CITIZENS.ROMAN.6_Cor">
+            <persName>CITIZENS.ROMAN.6_Cor</persName>
+          </person>
+          <person xml:id="CITIZENS.ROMAN.7_Cor">
+            <persName>CITIZENS.ROMAN.7_Cor</persName>
+          </person>
+          <person xml:id="CITIZENS.ROMAN.8_Cor">
+            <persName>CITIZENS.ROMAN.8_Cor</persName>
+          </person>
+          <person xml:id="SENATORS.ROMAN.0.2_Cor">
+            <persName>SENATORS.ROMAN.0.2_Cor</persName>
+          </person>
+          <person xml:id="AEDILES_Cor">
+            <persName>Aediles</persName>
+          </person>
+          <person xml:id="NOBLES.0.1_Cor">
+            <persName>Roman Lords, Gentry, Captains, Lictors, Trumpeters, Drummers, Musicians, Attendants, and Usher</persName>
+          </person>
+          <person xml:id="AEDILES.X.2_Cor">
+            <persName>AEDILES.X.2_Cor</persName>
+          </person>
+          <person xml:id="Nicanor_Cor">
+            <persName>Roman</persName>
+          </person>
+          <person xml:id="Adrian_Cor">
+            <persName>Volscian</persName>
+          </person>
+          <person xml:id="CITIZENS.ANTIUM.1_Cor">
+            <persName>Citizen</persName>
+          </person>
+          <person xml:id="SERVANTS.1_Cor">
+            <persName>SERVANTS.1_Cor</persName>
+          </person>
+          <person xml:id="SERVANTS.2_Cor">
+            <persName>SERVANTS.2_Cor</persName>
+          </person>
+          <person xml:id="SERVANTS.3_Cor">
+            <persName>SERVANTS.3_Cor</persName>
+          </person>
+          <person xml:id="AEDILES.X.3_Cor">
+            <persName>AEDILES.X.3_Cor</persName>
+          </person>
+          <person xml:id="MESSENGERS.TRIBUNES.1_Cor">
+            <persName>MESSENGERS.TRIBUNES.1_Cor</persName>
+          </person>
+          <person xml:id="MESSENGERS.TRIBUNES.2_Cor">
+            <persName>MESSENGERS.TRIBUNES.2_Cor</persName>
+          </person>
+          <person xml:id="CITIZENS.ROMAN.0.3_Cor">
+            <persName>CITIZENS.ROMAN.0.3_Cor</persName>
+          </person>
+          <person xml:id="SOLDIERS.VOLSCIAN.Lieutenant_Cor">
+            <persName>Lieutenant</persName>
+          </person>
+          <person xml:id="WATCHMEN.1_Cor">
+            <persName>WATCHMEN.1_Cor</persName>
+          </person>
+          <person xml:id="WATCHMEN.2_Cor">
+            <persName>WATCHMEN.2_Cor</persName>
+          </person>
+          <person xml:id="YoungMartius_Cor">
+            <persName>Young Martius</persName>
+          </person>
+          <person xml:id="CONSPIRATORS.0.1_Cor">
+            <persName>CONSPIRATORS.0.1_Cor</persName>
+          </person>
+          <person xml:id="CONSPIRATORS.0.2_Cor">
+            <persName>CONSPIRATORS.0.2_Cor</persName>
+          </person>
+          <person xml:id="CONSPIRATORS.0.3_Cor">
+            <persName>CONSPIRATORS.0.3_Cor</persName>
+          </person>
+          <person xml:id="LORDS.VOLSCIAN_Cor">
+            <persName>Senators Lords</persName>
+            <persName>Senators Lords</persName>
+          </person>
+          <person xml:id="LORDS.VOLSCIAN.0.1_Cor">
+            <persName>Roman Lords, Gentry, Captains, Lictors, Trumpeters, Drummers, Musicians, Attendants, and Usher</persName>
+          </person>
+          <person xml:id="CONSPIRATORS_Cor">
+            <persName>Conspirators</persName>
+          </person>
+          <person xml:id="CITIZENS.VOLSCIAN_Cor">
+            <persName>People</persName>
+          </person>
+          <person xml:id="LORDS.VOLSCIAN.0.2_Cor">
+            <persName>Roman Lords, Gentry, Captains, Lictors, Trumpeters, Drummers, Musicians, Attendants, and Usher</persName>
+          </person>
+          <person xml:id="LORDS.VOLSCIAN.0.3_Cor">
+            <persName>Roman Lords, Gentry, Captains, Lictors, Trumpeters, Drummers, Musicians, Attendants, and Usher</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/cymbeline.xml
+++ b/tei/cymbeline.xml
@@ -88,127 +88,127 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="ATTENDANTS.1_Cym">
+          <person xml:id="ATTENDANTS.1_Cym" sex="MALE">
             <persName>ATTENDANTS.1_Cym</persName>
           </person>
-          <person xml:id="ATTENDANTS.2_Cym">
+          <person xml:id="ATTENDANTS.2_Cym" sex="MALE">
             <persName>ATTENDANTS.2_Cym</persName>
           </person>
-          <person xml:id="Queen_Cym">
+          <person xml:id="Queen_Cym" sex="FEMALE">
             <persName>Queen</persName>
           </person>
-          <person xml:id="Posthumus_Cym">
+          <person xml:id="Posthumus_Cym" sex="MALE">
             <persName>Posthumus Leonatus</persName>
           </person>
-          <person xml:id="Imogen_Cym">
+          <person xml:id="Imogen_Cym" sex="FEMALE">
             <persName>Imogen</persName>
           </person>
-          <person xml:id="Cymbeline_Cym">
+          <person xml:id="Cymbeline_Cym" sex="MALE">
             <persName>Cymbeline</persName>
           </person>
-          <person xml:id="Pisanio_Cym">
+          <person xml:id="Pisanio_Cym" sex="MALE">
             <persName>Pisanio</persName>
           </person>
-          <person xml:id="ATTENDANTS.CLOTEN.1_Cym">
+          <person xml:id="ATTENDANTS.CLOTEN.1_Cym" sex="MALE">
             <persName>ATTENDANTS.CLOTEN.1_Cym</persName>
           </person>
-          <person xml:id="Cloten_Cym">
+          <person xml:id="Cloten_Cym" sex="MALE">
             <persName>Cloten</persName>
           </person>
-          <person xml:id="ATTENDANTS.CLOTEN.2_Cym">
+          <person xml:id="ATTENDANTS.CLOTEN.2_Cym" sex="MALE">
             <persName>ATTENDANTS.CLOTEN.2_Cym</persName>
           </person>
-          <person xml:id="LADIES.IMOGEN_Cym">
+          <person xml:id="LADIES.IMOGEN_Cym" sex="FEMALE">
             <persName>Lady</persName>
           </person>
-          <person xml:id="Iachimo_Cym">
+          <person xml:id="Iachimo_Cym" sex="MALE">
             <persName>Iachimo</persName>
           </person>
-          <person xml:id="Philario_Cym">
+          <person xml:id="Philario_Cym" sex="MALE">
             <persName>Philario</persName>
           </person>
-          <person xml:id="Frenchman_Cym">
+          <person xml:id="Frenchman_Cym" sex="MALE">
             <persName>Frenchman</persName>
           </person>
-          <person xml:id="LADIES.QUEEN.0.1_Cym">
+          <person xml:id="LADIES.QUEEN.0.1_Cym" sex="FEMALE">
             <persName>Lady</persName>
           </person>
-          <person xml:id="Cornelius_Cym">
+          <person xml:id="Cornelius_Cym" sex="MALE">
             <persName>Cornelius</persName>
           </person>
-          <person xml:id="MUSICIANS_Cym">
-            <persName>Lords, Ladies, Attendants, Musicians, a Dutchman, a Spaniard, Senators, Tribunes, Captains, and Soldiers</persName>
-          </person>
-          <person xml:id="MESSENGERS.1_Cym">
+          <personGrp xml:id="MUSICIANS_Cym" sex="UNKNOWN">
+            <name>Lords, Ladies, Attendants, Musicians, a Dutchman, a Spaniard, Senators, Tribunes, Captains, and Soldiers</name>
+          </personGrp>
+          <person xml:id="MESSENGERS.1_Cym" sex="MALE">
             <persName>MESSENGERS.1_Cym</persName>
           </person>
-          <person xml:id="Lucius_Cym">
+          <person xml:id="Lucius_Cym" sex="MALE">
             <persName>Caius Lucius</persName>
           </person>
-          <person xml:id="Belarius_Cym">
+          <person xml:id="Belarius_Cym" sex="MALE">
             <persName>Belarius</persName>
           </person>
-          <person xml:id="Guiderius_Cym">
+          <person xml:id="Guiderius_Cym" sex="MALE">
             <persName>Guiderius</persName>
           </person>
-          <person xml:id="Arviragus_Cym">
+          <person xml:id="Arviragus_Cym" sex="MALE">
             <persName>Arviragus</persName>
           </person>
-          <person xml:id="ATTENDANTS.0.1_Cym">
-            <persName>Lords, Ladies, Attendants, Musicians, a Dutchman, a Spaniard, Senators, Tribunes, Captains, and Soldiers</persName>
-          </person>
-          <person xml:id="SENATORS.1_Cym">
+          <personGrp xml:id="ATTENDANTS.0.1_Cym" sex="UNKNOWN">
+            <name>Lords, Ladies, Attendants, Musicians, a Dutchman, a Spaniard, Senators, Tribunes, Captains, and Soldiers</name>
+          </personGrp>
+          <person xml:id="SENATORS.1_Cym" sex="MALE">
             <persName>SENATORS.1_Cym</persName>
           </person>
-          <person xml:id="TRIBUNES.0.1_Cym">
+          <person xml:id="TRIBUNES.0.1_Cym" sex="MALE">
             <persName>TRIBUNES.0.1_Cym</persName>
           </person>
-          <person xml:id="SENATORS.2_Cym">
+          <person xml:id="SENATORS.2_Cym" sex="MALE">
             <persName>SENATORS.2_Cym</persName>
           </person>
-          <person xml:id="SOLDIERS.ROMAN.0.1_Cym">
+          <person xml:id="SOLDIERS.ROMAN.0.1_Cym" sex="MALE">
             <persName>SOLDIERS.ROMAN.0.1_Cym</persName>
           </person>
-          <person xml:id="Soothsayer_Cym">
+          <person xml:id="Soothsayer_Cym" sex="MALE">
             <persName>Soothsayer</persName>
           </person>
-          <person xml:id="ATTENDANTS.0.2_Cym">
-            <persName>Lords, Ladies, Attendants, Musicians, a Dutchman, a Spaniard, Senators, Tribunes, Captains, and Soldiers</persName>
-          </person>
-          <person xml:id="ATTENDANTS.3_Cym">
+          <personGrp xml:id="ATTENDANTS.0.2_Cym" sex="UNKNOWN">
+            <name>Lords, Ladies, Attendants, Musicians, a Dutchman, a Spaniard, Senators, Tribunes, Captains, and Soldiers</name>
+          </personGrp>
+          <person xml:id="ATTENDANTS.3_Cym" sex="MALE">
             <persName>Lord</persName>
           </person>
-          <person xml:id="SOLDIERS.BRITON.0.1_Cym">
+          <person xml:id="SOLDIERS.BRITON.0.1_Cym" sex="MALE">
             <persName>SOLDIERS.BRITON.0.1_Cym</persName>
           </person>
-          <person xml:id="SOLDIERS.BRITON.0.2_Cym">
+          <person xml:id="SOLDIERS.BRITON.0.2_Cym" sex="MALE">
             <persName>SOLDIERS.BRITON.0.2_Cym</persName>
           </person>
-          <person xml:id="JAILERS.1_Cym">
+          <person xml:id="JAILERS.1_Cym" sex="MALE">
             <persName>JAILERS.1_Cym</persName>
           </person>
-          <person xml:id="JAILERS.2_Cym">
+          <person xml:id="JAILERS.2_Cym" sex="MALE">
             <persName>JAILERS.2_Cym</persName>
           </person>
-          <person xml:id="GHOSTS.Father_Cym">
+          <person xml:id="GHOSTS.Father_Cym" sex="MALE">
             <persName>Sicilius Leonatus</persName>
           </person>
-          <person xml:id="GHOSTS.Mother_Cym">
+          <person xml:id="GHOSTS.Mother_Cym" sex="FEMALE">
             <persName>Mother</persName>
           </person>
-          <person xml:id="GHOSTS.BROTHERS.1_Cym">
+          <person xml:id="GHOSTS.BROTHERS.1_Cym" sex="MALE">
             <persName>GHOSTS.BROTHERS.1_Cym</persName>
           </person>
-          <person xml:id="GHOSTS.BROTHERS.2_Cym">
+          <person xml:id="GHOSTS.BROTHERS.2_Cym" sex="MALE">
             <persName>GHOSTS.BROTHERS.2_Cym</persName>
           </person>
-          <person xml:id="Jupiter_Cym">
+          <person xml:id="Jupiter_Cym" ana="http://www.wikidata.org/entity/Q4649">
             <persName>Jupiter</persName>
           </person>
-          <person xml:id="MESSENGERS.2_Cym">
+          <person xml:id="MESSENGERS.2_Cym" sex="MALE">
             <persName>MESSENGERS.2_Cym</persName>
           </person>
-          <person xml:id="LADIES.QUEEN_Cym">
+          <person xml:id="LADIES.QUEEN_Cym" sex="FEMALE">
             <persName>LADIES.QUEEN_Cym</persName>
           </person>
         </listPerson>

--- a/tei/cymbeline.xml
+++ b/tei/cymbeline.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,134 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="ATTENDANTS.1_Cym"><persName>ATTENDANTS.1_Cym</persName></person><person xml:id="ATTENDANTS.2_Cym"><persName>ATTENDANTS.2_Cym</persName></person><person xml:id="Queen_Cym"><persName>Queen</persName></person><person xml:id="Posthumus_Cym"><persName>Posthumus Leonatus</persName></person><person xml:id="Imogen_Cym"><persName>Imogen</persName></person><person xml:id="Cymbeline_Cym"><persName>Cymbeline</persName></person><person xml:id="Pisanio_Cym"><persName>Pisanio</persName></person><person xml:id="ATTENDANTS.CLOTEN.1_Cym"><persName>ATTENDANTS.CLOTEN.1_Cym</persName></person><person xml:id="Cloten_Cym"><persName>Cloten</persName></person><person xml:id="ATTENDANTS.CLOTEN.2_Cym"><persName>ATTENDANTS.CLOTEN.2_Cym</persName></person><person xml:id="LADIES.IMOGEN_Cym"><persName>Lady</persName></person><person xml:id="Iachimo_Cym"><persName>Iachimo</persName></person><person xml:id="Philario_Cym"><persName>Philario</persName></person><person xml:id="Frenchman_Cym"><persName>Frenchman</persName></person><person xml:id="LADIES.QUEEN.0.1_Cym"><persName>Lady</persName></person><person xml:id="Cornelius_Cym"><persName>Cornelius</persName></person><person xml:id="MUSICIANS_Cym"><persName>Lords, Ladies, Attendants, Musicians, a Dutchman, a Spaniard, Senators, Tribunes, Captains, and Soldiers</persName></person><person xml:id="MESSENGERS.1_Cym"><persName>MESSENGERS.1_Cym</persName></person><person xml:id="Lucius_Cym"><persName>Caius Lucius</persName></person><person xml:id="Belarius_Cym"><persName>Belarius</persName></person><person xml:id="Guiderius_Cym"><persName>Guiderius</persName></person><person xml:id="Arviragus_Cym"><persName>Arviragus</persName></person><person xml:id="ATTENDANTS.0.1_Cym"><persName>Lords, Ladies, Attendants, Musicians, a Dutchman, a Spaniard, Senators, Tribunes, Captains, and Soldiers</persName></person><person xml:id="SENATORS.1_Cym"><persName>SENATORS.1_Cym</persName></person><person xml:id="TRIBUNES.0.1_Cym"><persName>TRIBUNES.0.1_Cym</persName></person><person xml:id="SENATORS.2_Cym"><persName>SENATORS.2_Cym</persName></person><person xml:id="SOLDIERS.ROMAN.0.1_Cym"><persName>SOLDIERS.ROMAN.0.1_Cym</persName></person><person xml:id="Soothsayer_Cym"><persName>Soothsayer</persName></person><person xml:id="ATTENDANTS.0.2_Cym"><persName>Lords, Ladies, Attendants, Musicians, a Dutchman, a Spaniard, Senators, Tribunes, Captains, and Soldiers</persName></person><person xml:id="ATTENDANTS.3_Cym"><persName>Lord</persName></person><person xml:id="SOLDIERS.BRITON.0.1_Cym"><persName>SOLDIERS.BRITON.0.1_Cym</persName></person><person xml:id="SOLDIERS.BRITON.0.2_Cym"><persName>SOLDIERS.BRITON.0.2_Cym</persName></person><person xml:id="JAILERS.1_Cym"><persName>JAILERS.1_Cym</persName></person><person xml:id="JAILERS.2_Cym"><persName>JAILERS.2_Cym</persName></person><person xml:id="GHOSTS.Father_Cym"><persName>Sicilius Leonatus</persName></person><person xml:id="GHOSTS.Mother_Cym"><persName>Mother</persName></person><person xml:id="GHOSTS.BROTHERS.1_Cym"><persName>GHOSTS.BROTHERS.1_Cym</persName></person><person xml:id="GHOSTS.BROTHERS.2_Cym"><persName>GHOSTS.BROTHERS.2_Cym</persName></person><person xml:id="Jupiter_Cym"><persName>Jupiter</persName></person><person xml:id="MESSENGERS.2_Cym"><persName>MESSENGERS.2_Cym</persName></person><person xml:id="LADIES.QUEEN_Cym"><persName>LADIES.QUEEN_Cym</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="ATTENDANTS.1_Cym">
+            <persName>ATTENDANTS.1_Cym</persName>
+          </person>
+          <person xml:id="ATTENDANTS.2_Cym">
+            <persName>ATTENDANTS.2_Cym</persName>
+          </person>
+          <person xml:id="Queen_Cym">
+            <persName>Queen</persName>
+          </person>
+          <person xml:id="Posthumus_Cym">
+            <persName>Posthumus Leonatus</persName>
+          </person>
+          <person xml:id="Imogen_Cym">
+            <persName>Imogen</persName>
+          </person>
+          <person xml:id="Cymbeline_Cym">
+            <persName>Cymbeline</persName>
+          </person>
+          <person xml:id="Pisanio_Cym">
+            <persName>Pisanio</persName>
+          </person>
+          <person xml:id="ATTENDANTS.CLOTEN.1_Cym">
+            <persName>ATTENDANTS.CLOTEN.1_Cym</persName>
+          </person>
+          <person xml:id="Cloten_Cym">
+            <persName>Cloten</persName>
+          </person>
+          <person xml:id="ATTENDANTS.CLOTEN.2_Cym">
+            <persName>ATTENDANTS.CLOTEN.2_Cym</persName>
+          </person>
+          <person xml:id="LADIES.IMOGEN_Cym">
+            <persName>Lady</persName>
+          </person>
+          <person xml:id="Iachimo_Cym">
+            <persName>Iachimo</persName>
+          </person>
+          <person xml:id="Philario_Cym">
+            <persName>Philario</persName>
+          </person>
+          <person xml:id="Frenchman_Cym">
+            <persName>Frenchman</persName>
+          </person>
+          <person xml:id="LADIES.QUEEN.0.1_Cym">
+            <persName>Lady</persName>
+          </person>
+          <person xml:id="Cornelius_Cym">
+            <persName>Cornelius</persName>
+          </person>
+          <person xml:id="MUSICIANS_Cym">
+            <persName>Lords, Ladies, Attendants, Musicians, a Dutchman, a Spaniard, Senators, Tribunes, Captains, and Soldiers</persName>
+          </person>
+          <person xml:id="MESSENGERS.1_Cym">
+            <persName>MESSENGERS.1_Cym</persName>
+          </person>
+          <person xml:id="Lucius_Cym">
+            <persName>Caius Lucius</persName>
+          </person>
+          <person xml:id="Belarius_Cym">
+            <persName>Belarius</persName>
+          </person>
+          <person xml:id="Guiderius_Cym">
+            <persName>Guiderius</persName>
+          </person>
+          <person xml:id="Arviragus_Cym">
+            <persName>Arviragus</persName>
+          </person>
+          <person xml:id="ATTENDANTS.0.1_Cym">
+            <persName>Lords, Ladies, Attendants, Musicians, a Dutchman, a Spaniard, Senators, Tribunes, Captains, and Soldiers</persName>
+          </person>
+          <person xml:id="SENATORS.1_Cym">
+            <persName>SENATORS.1_Cym</persName>
+          </person>
+          <person xml:id="TRIBUNES.0.1_Cym">
+            <persName>TRIBUNES.0.1_Cym</persName>
+          </person>
+          <person xml:id="SENATORS.2_Cym">
+            <persName>SENATORS.2_Cym</persName>
+          </person>
+          <person xml:id="SOLDIERS.ROMAN.0.1_Cym">
+            <persName>SOLDIERS.ROMAN.0.1_Cym</persName>
+          </person>
+          <person xml:id="Soothsayer_Cym">
+            <persName>Soothsayer</persName>
+          </person>
+          <person xml:id="ATTENDANTS.0.2_Cym">
+            <persName>Lords, Ladies, Attendants, Musicians, a Dutchman, a Spaniard, Senators, Tribunes, Captains, and Soldiers</persName>
+          </person>
+          <person xml:id="ATTENDANTS.3_Cym">
+            <persName>Lord</persName>
+          </person>
+          <person xml:id="SOLDIERS.BRITON.0.1_Cym">
+            <persName>SOLDIERS.BRITON.0.1_Cym</persName>
+          </person>
+          <person xml:id="SOLDIERS.BRITON.0.2_Cym">
+            <persName>SOLDIERS.BRITON.0.2_Cym</persName>
+          </person>
+          <person xml:id="JAILERS.1_Cym">
+            <persName>JAILERS.1_Cym</persName>
+          </person>
+          <person xml:id="JAILERS.2_Cym">
+            <persName>JAILERS.2_Cym</persName>
+          </person>
+          <person xml:id="GHOSTS.Father_Cym">
+            <persName>Sicilius Leonatus</persName>
+          </person>
+          <person xml:id="GHOSTS.Mother_Cym">
+            <persName>Mother</persName>
+          </person>
+          <person xml:id="GHOSTS.BROTHERS.1_Cym">
+            <persName>GHOSTS.BROTHERS.1_Cym</persName>
+          </person>
+          <person xml:id="GHOSTS.BROTHERS.2_Cym">
+            <persName>GHOSTS.BROTHERS.2_Cym</persName>
+          </person>
+          <person xml:id="Jupiter_Cym">
+            <persName>Jupiter</persName>
+          </person>
+          <person xml:id="MESSENGERS.2_Cym">
+            <persName>MESSENGERS.2_Cym</persName>
+          </person>
+          <person xml:id="LADIES.QUEEN_Cym">
+            <persName>LADIES.QUEEN_Cym</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/hamlet.xml
+++ b/tei/hamlet.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,125 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Barnardo_Ham"><persName>Barnardo</persName></person><person xml:id="Francisco_Ham"><persName>Francisco</persName></person><person xml:id="Horatio_Ham"><persName>Horatio</persName></person><person xml:id="Marcellus_Ham"><persName>Marcellus</persName></person><person xml:id="Claudius_Ham"><persName>King Claudius</persName></person><person xml:id="Cornelius_Ham"><persName>Cornelius</persName></person><person xml:id="Voltemand_Ham"><persName>Voltemand</persName></person><person xml:id="Laertes_Ham"><persName>Laertes</persName></person><person xml:id="Polonius_Ham"><persName>Polonius</persName></person><person xml:id="Hamlet_Ham"><persName>Hamlet</persName></person><person xml:id="Gertrude_Ham"><persName>Queen Gertrude</persName></person><person xml:id="Ophelia_Ham"><persName>Ophelia</persName></person><person xml:id="Ghost_Ham"><persName>The Ghost</persName></person><person xml:id="Reynaldo_Ham"><persName>Reynaldo</persName></person><person xml:id="Rosencrantz_Ham"><persName>Rosencrantz</persName></person><person xml:id="Guildenstern_Ham"><persName>Guildenstern</persName></person><person xml:id="PLAYERS.1_Ham"><persName>PLAYERS.1_Ham</persName></person><person xml:id="PLAYERS.0.1_Ham"><persName>PLAYERS.0.1_Ham</persName></person><person xml:id="PLAYERS.Prologue_Ham"><persName>PLAYERS.Prologue_Ham</persName></person><person xml:id="PLAYERS.King_Ham"><persName>PLAYERS.King_Ham</persName></person><person xml:id="PLAYERS.Queen_Ham"><persName>PLAYERS.Queen_Ham</persName></person><person xml:id="PLAYERS.Lucianus_Ham"><persName>PLAYERS.Lucianus_Ham</persName></person><person xml:id="ATTENDANTS.GUARDS_Ham"><persName>Attendants, Lords, Guards, Musicians, Laertes’s Followers, Soldiers, Officers</persName></person><person xml:id="Fortinbras_Ham"><persName>Fortinbras</persName></person><person xml:id="SOLDIERS.FORTINBRAS.Captain_Ham"><persName>SOLDIERS.FORTINBRAS.Captain_Ham</persName></person><person xml:id="ATTENDANTS.1_Ham"><persName>courtiers at the Danish court</persName></person><person xml:id="MESSENGERS.1_Ham"><persName>MESSENGERS.1_Ham</persName></person><person xml:id="FOLLOWERS.LAERTES_Ham"><persName>Attendants, Lords, Guards, Musicians, Laertes’s Followers, Soldiers, Officers</persName></person><person xml:id="ATTENDANTS.0.1_Ham"><persName>Attendants, Lords, Guards, Musicians, Laertes’s Followers, Soldiers, Officers</persName></person><person xml:id="SAILORS.0.1_Ham"><persName>SAILORS.0.1_Ham</persName></person><person xml:id="MESSENGERS.2_Ham"><persName>MESSENGERS.2_Ham</persName></person><person xml:id="Gravedigger_Ham"><persName>Gravedigger_Ham</persName></person><person xml:id="GravediggersCompanion_Ham"><persName>GravediggersCompanion_Ham</persName></person><person xml:id="Doctor_Ham"><persName>Doctor_Ham</persName></person><person xml:id="ATTENDANTS_Ham"><persName>Attendants, Lords, Guards, Musicians, Laertes’s Followers, Soldiers, Officers</persName></person><person xml:id="Osric_Ham"><persName>Osric</persName></person><person xml:id="ATTENDANTS.2_Ham"><persName>courtiers at the Danish court</persName></person><person xml:id="AMBASSADORS_Ham"><persName>Ambassadors to Denmark from England</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Barnardo_Ham">
+            <persName>Barnardo</persName>
+          </person>
+          <person xml:id="Francisco_Ham">
+            <persName>Francisco</persName>
+          </person>
+          <person xml:id="Horatio_Ham">
+            <persName>Horatio</persName>
+          </person>
+          <person xml:id="Marcellus_Ham">
+            <persName>Marcellus</persName>
+          </person>
+          <person xml:id="Claudius_Ham">
+            <persName>King Claudius</persName>
+          </person>
+          <person xml:id="Cornelius_Ham">
+            <persName>Cornelius</persName>
+          </person>
+          <person xml:id="Voltemand_Ham">
+            <persName>Voltemand</persName>
+          </person>
+          <person xml:id="Laertes_Ham">
+            <persName>Laertes</persName>
+          </person>
+          <person xml:id="Polonius_Ham">
+            <persName>Polonius</persName>
+          </person>
+          <person xml:id="Hamlet_Ham">
+            <persName>Hamlet</persName>
+          </person>
+          <person xml:id="Gertrude_Ham">
+            <persName>Queen Gertrude</persName>
+          </person>
+          <person xml:id="Ophelia_Ham">
+            <persName>Ophelia</persName>
+          </person>
+          <person xml:id="Ghost_Ham">
+            <persName>The Ghost</persName>
+          </person>
+          <person xml:id="Reynaldo_Ham">
+            <persName>Reynaldo</persName>
+          </person>
+          <person xml:id="Rosencrantz_Ham">
+            <persName>Rosencrantz</persName>
+          </person>
+          <person xml:id="Guildenstern_Ham">
+            <persName>Guildenstern</persName>
+          </person>
+          <person xml:id="PLAYERS.1_Ham">
+            <persName>PLAYERS.1_Ham</persName>
+          </person>
+          <person xml:id="PLAYERS.0.1_Ham">
+            <persName>PLAYERS.0.1_Ham</persName>
+          </person>
+          <person xml:id="PLAYERS.Prologue_Ham">
+            <persName>PLAYERS.Prologue_Ham</persName>
+          </person>
+          <person xml:id="PLAYERS.King_Ham">
+            <persName>PLAYERS.King_Ham</persName>
+          </person>
+          <person xml:id="PLAYERS.Queen_Ham">
+            <persName>PLAYERS.Queen_Ham</persName>
+          </person>
+          <person xml:id="PLAYERS.Lucianus_Ham">
+            <persName>PLAYERS.Lucianus_Ham</persName>
+          </person>
+          <person xml:id="ATTENDANTS.GUARDS_Ham">
+            <persName>Attendants, Lords, Guards, Musicians, Laertes’s Followers, Soldiers, Officers</persName>
+          </person>
+          <person xml:id="Fortinbras_Ham">
+            <persName>Fortinbras</persName>
+          </person>
+          <person xml:id="SOLDIERS.FORTINBRAS.Captain_Ham">
+            <persName>SOLDIERS.FORTINBRAS.Captain_Ham</persName>
+          </person>
+          <person xml:id="ATTENDANTS.1_Ham">
+            <persName>courtiers at the Danish court</persName>
+          </person>
+          <person xml:id="MESSENGERS.1_Ham">
+            <persName>MESSENGERS.1_Ham</persName>
+          </person>
+          <person xml:id="FOLLOWERS.LAERTES_Ham">
+            <persName>Attendants, Lords, Guards, Musicians, Laertes’s Followers, Soldiers, Officers</persName>
+          </person>
+          <person xml:id="ATTENDANTS.0.1_Ham">
+            <persName>Attendants, Lords, Guards, Musicians, Laertes’s Followers, Soldiers, Officers</persName>
+          </person>
+          <person xml:id="SAILORS.0.1_Ham">
+            <persName>SAILORS.0.1_Ham</persName>
+          </person>
+          <person xml:id="MESSENGERS.2_Ham">
+            <persName>MESSENGERS.2_Ham</persName>
+          </person>
+          <person xml:id="Gravedigger_Ham">
+            <persName>Gravedigger_Ham</persName>
+          </person>
+          <person xml:id="GravediggersCompanion_Ham">
+            <persName>GravediggersCompanion_Ham</persName>
+          </person>
+          <person xml:id="Doctor_Ham">
+            <persName>Doctor_Ham</persName>
+          </person>
+          <person xml:id="ATTENDANTS_Ham">
+            <persName>Attendants, Lords, Guards, Musicians, Laertes’s Followers, Soldiers, Officers</persName>
+          </person>
+          <person xml:id="Osric_Ham">
+            <persName>Osric</persName>
+          </person>
+          <person xml:id="ATTENDANTS.2_Ham">
+            <persName>courtiers at the Danish court</persName>
+          </person>
+          <person xml:id="AMBASSADORS_Ham">
+            <persName>Ambassadors to Denmark from England</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/hamlet.xml
+++ b/tei/hamlet.xml
@@ -88,120 +88,120 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Barnardo_Ham">
+          <person xml:id="Barnardo_Ham" sex="MALE">
             <persName>Barnardo</persName>
           </person>
-          <person xml:id="Francisco_Ham">
+          <person xml:id="Francisco_Ham" sex="MALE">
             <persName>Francisco</persName>
           </person>
-          <person xml:id="Horatio_Ham">
+          <person xml:id="Horatio_Ham" sex="MALE">
             <persName>Horatio</persName>
           </person>
-          <person xml:id="Marcellus_Ham">
+          <person xml:id="Marcellus_Ham" sex="MALE">
             <persName>Marcellus</persName>
           </person>
-          <person xml:id="Claudius_Ham">
+          <person xml:id="Claudius_Ham" sex="MALE">
             <persName>King Claudius</persName>
           </person>
-          <person xml:id="Cornelius_Ham">
+          <person xml:id="Cornelius_Ham" sex="MALE">
             <persName>Cornelius</persName>
           </person>
-          <person xml:id="Voltemand_Ham">
+          <person xml:id="Voltemand_Ham" sex="MALE">
             <persName>Voltemand</persName>
           </person>
-          <person xml:id="Laertes_Ham">
+          <person xml:id="Laertes_Ham" sex="MALE">
             <persName>Laertes</persName>
           </person>
-          <person xml:id="Polonius_Ham">
+          <person xml:id="Polonius_Ham" sex="MALE">
             <persName>Polonius</persName>
           </person>
-          <person xml:id="Hamlet_Ham">
+          <person xml:id="Hamlet_Ham" ana="http://www.wikidata.org/entity/Q462225">
             <persName>Hamlet</persName>
           </person>
-          <person xml:id="Gertrude_Ham">
+          <person xml:id="Gertrude_Ham" ana="http://www.wikidata.org/entity/Q258776">
             <persName>Queen Gertrude</persName>
           </person>
-          <person xml:id="Ophelia_Ham">
+          <person xml:id="Ophelia_Ham" ana="http://www.wikidata.org/entity/Q16131373">
             <persName>Ophelia</persName>
           </person>
-          <person xml:id="Ghost_Ham">
+          <person xml:id="Ghost_Ham" ana="http://www.wikidata.org/entity/Q644262">
             <persName>The Ghost</persName>
           </person>
-          <person xml:id="Reynaldo_Ham">
+          <person xml:id="Reynaldo_Ham" sex="MALE">
             <persName>Reynaldo</persName>
           </person>
-          <person xml:id="Rosencrantz_Ham">
+          <person xml:id="Rosencrantz_Ham" ana="http://www.wikidata.org/entity/Q10906968">
             <persName>Rosencrantz</persName>
           </person>
-          <person xml:id="Guildenstern_Ham">
+          <person xml:id="Guildenstern_Ham" ana="http://www.wikidata.org/entity/Q12322311">
             <persName>Guildenstern</persName>
           </person>
-          <person xml:id="PLAYERS.1_Ham">
-            <persName>PLAYERS.1_Ham</persName>
-          </person>
-          <person xml:id="PLAYERS.0.1_Ham">
-            <persName>PLAYERS.0.1_Ham</persName>
-          </person>
-          <person xml:id="PLAYERS.Prologue_Ham">
-            <persName>PLAYERS.Prologue_Ham</persName>
-          </person>
-          <person xml:id="PLAYERS.King_Ham">
-            <persName>PLAYERS.King_Ham</persName>
-          </person>
-          <person xml:id="PLAYERS.Queen_Ham">
-            <persName>PLAYERS.Queen_Ham</persName>
-          </person>
-          <person xml:id="PLAYERS.Lucianus_Ham">
-            <persName>PLAYERS.Lucianus_Ham</persName>
-          </person>
-          <person xml:id="ATTENDANTS.GUARDS_Ham">
-            <persName>Attendants, Lords, Guards, Musicians, Laertes’s Followers, Soldiers, Officers</persName>
-          </person>
-          <person xml:id="Fortinbras_Ham">
+          <personGrp xml:id="PLAYERS.1_Ham" sex="UNKNOWN">
+            <name>PLAYERS.1_Ham</name>
+          </personGrp>
+          <personGrp xml:id="PLAYERS.0.1_Ham" sex="UNKNOWN">
+            <name>PLAYERS.0.1_Ham</name>
+          </personGrp>
+          <personGrp xml:id="PLAYERS.Prologue_Ham" sex="UNKNOWN">
+            <name>PLAYERS.Prologue_Ham</name>
+          </personGrp>
+          <personGrp xml:id="PLAYERS.King_Ham" sex="UNKNOWN">
+            <name>PLAYERS.King_Ham</name>
+          </personGrp>
+          <personGrp xml:id="PLAYERS.Queen_Ham" sex="UNKNOWN">
+            <name>PLAYERS.Queen_Ham</name>
+          </personGrp>
+          <personGrp xml:id="PLAYERS.Lucianus_Ham" sex="UNKNOWN">
+            <name>PLAYERS.Lucianus_Ham</name>
+          </personGrp>
+          <personGrp xml:id="ATTENDANTS.GUARDS_Ham" sex="UNKNOWN">
+            <name>Attendants, Lords, Guards, Musicians, Laertes’s Followers, Soldiers, Officers</name>
+          </personGrp>
+          <person xml:id="Fortinbras_Ham" sex="MALE">
             <persName>Fortinbras</persName>
           </person>
-          <person xml:id="SOLDIERS.FORTINBRAS.Captain_Ham">
-            <persName>SOLDIERS.FORTINBRAS.Captain_Ham</persName>
-          </person>
-          <person xml:id="ATTENDANTS.1_Ham">
-            <persName>courtiers at the Danish court</persName>
-          </person>
-          <person xml:id="MESSENGERS.1_Ham">
-            <persName>MESSENGERS.1_Ham</persName>
-          </person>
-          <person xml:id="FOLLOWERS.LAERTES_Ham">
-            <persName>Attendants, Lords, Guards, Musicians, Laertes’s Followers, Soldiers, Officers</persName>
-          </person>
-          <person xml:id="ATTENDANTS.0.1_Ham">
-            <persName>Attendants, Lords, Guards, Musicians, Laertes’s Followers, Soldiers, Officers</persName>
-          </person>
-          <person xml:id="SAILORS.0.1_Ham">
-            <persName>SAILORS.0.1_Ham</persName>
-          </person>
-          <person xml:id="MESSENGERS.2_Ham">
-            <persName>MESSENGERS.2_Ham</persName>
-          </person>
-          <person xml:id="Gravedigger_Ham">
+          <personGrp xml:id="SOLDIERS.FORTINBRAS.Captain_Ham" sex="UNKNOWN">
+            <name>SOLDIERS.FORTINBRAS.Captain_Ham</name>
+          </personGrp>
+          <personGrp xml:id="ATTENDANTS.1_Ham" sex="UNKNOWN">
+            <name>courtiers at the Danish court</name>
+          </personGrp>
+          <personGrp xml:id="MESSENGERS.1_Ham" sex="UNKNOWN">
+            <name>MESSENGERS.1_Ham</name>
+          </personGrp>
+          <personGrp xml:id="FOLLOWERS.LAERTES_Ham" sex="UNKNOWN">
+            <name>Attendants, Lords, Guards, Musicians, Laertes’s Followers, Soldiers, Officers</name>
+          </personGrp>
+          <personGrp xml:id="ATTENDANTS.0.1_Ham" sex="UNKNOWN">
+            <name>Attendants, Lords, Guards, Musicians, Laertes’s Followers, Soldiers, Officers</name>
+          </personGrp>
+          <personGrp xml:id="SAILORS.0.1_Ham" sex="UNKNOWN">
+            <name>SAILORS.0.1_Ham</name>
+          </personGrp>
+          <personGrp xml:id="MESSENGERS.2_Ham" sex="UNKNOWN">
+            <name>MESSENGERS.2_Ham</name>
+          </personGrp>
+          <person xml:id="Gravedigger_Ham" sex="MALE">
             <persName>Gravedigger_Ham</persName>
           </person>
-          <person xml:id="GravediggersCompanion_Ham">
+          <person xml:id="GravediggersCompanion_Ham" sex="MALE">
             <persName>GravediggersCompanion_Ham</persName>
           </person>
-          <person xml:id="Doctor_Ham">
+          <person xml:id="Doctor_Ham" sex="MALE">
             <persName>Doctor_Ham</persName>
           </person>
-          <person xml:id="ATTENDANTS_Ham">
-            <persName>Attendants, Lords, Guards, Musicians, Laertes’s Followers, Soldiers, Officers</persName>
-          </person>
-          <person xml:id="Osric_Ham">
+          <personGrp xml:id="ATTENDANTS_Ham" sex="UNKNOWN">
+            <name>Attendants, Lords, Guards, Musicians, Laertes’s Followers, Soldiers, Officers</name>
+          </personGrp>
+          <person xml:id="Osric_Ham" sex="MALE">
             <persName>Osric</persName>
           </person>
-          <person xml:id="ATTENDANTS.2_Ham">
-            <persName>courtiers at the Danish court</persName>
-          </person>
-          <person xml:id="AMBASSADORS_Ham">
-            <persName>Ambassadors to Denmark from England</persName>
-          </person>
+          <personGrp xml:id="ATTENDANTS.2_Ham" sex="UNKNOWN">
+            <name>courtiers at the Danish court</name>
+          </personGrp>
+          <personGrp xml:id="AMBASSADORS_Ham" sex="UNKNOWN">
+            <name>Ambassadors to Denmark from England</name>
+          </personGrp>
         </listPerson>
       </particDesc>
     </profileDesc>

--- a/tei/henry-iv-part-i.xml
+++ b/tei/henry-iv-part-i.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts encodes the edition of each play by Barbara Mowat and Paul Werstine in TEI Simple. The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptionss and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,119 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="HenryIV_1H4"><persName>King Henry IV</persName></person><person xml:id="Westmoreland_1H4"><persName>Earl of Westmoreland</persName></person><person xml:id="Falstaff_1H4"><persName>Sir John Falstaff</persName></person><person xml:id="HenryV_H5"><persName>Prince Hal</persName></person><person xml:id="Poins_1H4"><persName>Poins</persName></person><person xml:id="Worcester_1H4"><persName>Earl of Worcester</persName></person><person xml:id="Northumberland_R2"><persName>Earl of Northumberland</persName></person><person xml:id="Hotspur_R2"><persName>Hotspur</persName></person><person xml:id="Blunt_1H4"><persName>Sir Walter Blunt</persName></person><person xml:id="TRAVELERS.CARRIERS.1_1H4"><persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName></person><person xml:id="Ostler_1H4"><persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName></person><person xml:id="TRAVELERS.CARRIERS.2_1H4"><persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName></person><person xml:id="Gadshill_1H4"><persName>Gadshill</persName></person><person xml:id="Chamberlain_1H4"><persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName></person><person xml:id="Bardolph_1H4"><persName>Bardolph</persName></person><person xml:id="Peto_1H4"><persName>Peto</persName></person><person xml:id="TRAVELERS.GENTLEMEN.0.1_1H4"><persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName></person><person xml:id="TRAVELERS.CARRIERS_1H4"><persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName></person><person xml:id="TRAVELERS.GENTLEMEN_1H4"><persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName></person><person xml:id="LadyPercy_1H4"><persName>Lady Percy</persName></person><person xml:id="SERVANTS.HOTSPUR.1_1H4"><persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName></person><person xml:id="DRAWERS.Francis_1H4"><persName>Francis</persName></person><person xml:id="Vintner_1H4"><persName>Vintner</persName></person><person xml:id="MistressQuickly_1H4"><persName>Hostess</persName></person><person xml:id="Sheriff_1H4"><persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName></person><person xml:id="TRAVELERS.CARRIERS.X_1H4"><persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName></person><person xml:id="Mortimer_1H4"><persName>Edmund Mortimer</persName></person><person xml:id="Glendower_1H4"><persName>Owen Glendower</persName></person><person xml:id="Douglas_1H4"><persName>Douglas</persName></person><person xml:id="MESSENGERS.X_1H4"><persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName></person><person xml:id="Vernon_1H4"><persName>Sir Richard Vernon</persName></person><person xml:id="Archbishop_1H4"><persName>Archbishop</persName></person><person xml:id="SirMichael_1H4"><persName>Sir Michael</persName></person><person xml:id="MESSENGERS.1_1H4"><persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName></person><person xml:id="MESSENGERS.2_1H4"><persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName></person><person xml:id="Bedford_H5"><persName>Lord John of Lancaster</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="HenryIV_1H4">
+            <persName>King Henry IV</persName>
+          </person>
+          <person xml:id="Westmoreland_1H4">
+            <persName>Earl of Westmoreland</persName>
+          </person>
+          <person xml:id="Falstaff_1H4">
+            <persName>Sir John Falstaff</persName>
+          </person>
+          <person xml:id="HenryV_H5">
+            <persName>Prince Hal</persName>
+          </person>
+          <person xml:id="Poins_1H4">
+            <persName>Poins</persName>
+          </person>
+          <person xml:id="Worcester_1H4">
+            <persName>Earl of Worcester</persName>
+          </person>
+          <person xml:id="Northumberland_R2">
+            <persName>Earl of Northumberland</persName>
+          </person>
+          <person xml:id="Hotspur_R2">
+            <persName>Hotspur</persName>
+          </person>
+          <person xml:id="Blunt_1H4">
+            <persName>Sir Walter Blunt</persName>
+          </person>
+          <person xml:id="TRAVELERS.CARRIERS.1_1H4">
+            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
+          </person>
+          <person xml:id="Ostler_1H4">
+            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
+          </person>
+          <person xml:id="TRAVELERS.CARRIERS.2_1H4">
+            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
+          </person>
+          <person xml:id="Gadshill_1H4">
+            <persName>Gadshill</persName>
+          </person>
+          <person xml:id="Chamberlain_1H4">
+            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
+          </person>
+          <person xml:id="Bardolph_1H4">
+            <persName>Bardolph</persName>
+          </person>
+          <person xml:id="Peto_1H4">
+            <persName>Peto</persName>
+          </person>
+          <person xml:id="TRAVELERS.GENTLEMEN.0.1_1H4">
+            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
+          </person>
+          <person xml:id="TRAVELERS.CARRIERS_1H4">
+            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
+          </person>
+          <person xml:id="TRAVELERS.GENTLEMEN_1H4">
+            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
+          </person>
+          <person xml:id="LadyPercy_1H4">
+            <persName>Lady Percy</persName>
+          </person>
+          <person xml:id="SERVANTS.HOTSPUR.1_1H4">
+            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
+          </person>
+          <person xml:id="DRAWERS.Francis_1H4">
+            <persName>Francis</persName>
+          </person>
+          <person xml:id="Vintner_1H4">
+            <persName>Vintner</persName>
+          </person>
+          <person xml:id="MistressQuickly_1H4">
+            <persName>Hostess</persName>
+          </person>
+          <person xml:id="Sheriff_1H4">
+            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
+          </person>
+          <person xml:id="TRAVELERS.CARRIERS.X_1H4">
+            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
+          </person>
+          <person xml:id="Mortimer_1H4">
+            <persName>Edmund Mortimer</persName>
+          </person>
+          <person xml:id="Glendower_1H4">
+            <persName>Owen Glendower</persName>
+          </person>
+          <person xml:id="Douglas_1H4">
+            <persName>Douglas</persName>
+          </person>
+          <person xml:id="MESSENGERS.X_1H4">
+            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
+          </person>
+          <person xml:id="Vernon_1H4">
+            <persName>Sir Richard Vernon</persName>
+          </person>
+          <person xml:id="Archbishop_1H4">
+            <persName>Archbishop</persName>
+          </person>
+          <person xml:id="SirMichael_1H4">
+            <persName>Sir Michael</persName>
+          </person>
+          <person xml:id="MESSENGERS.1_1H4">
+            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
+          </person>
+          <person xml:id="MESSENGERS.2_1H4">
+            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
+          </person>
+          <person xml:id="Bedford_H5">
+            <persName>Lord John of Lancaster</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/henry-iv-part-i.xml
+++ b/tei/henry-iv-part-i.xml
@@ -88,112 +88,112 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="HenryIV_1H4">
+          <person xml:id="HenryIV_1H4" ana="http://www.wikidata.org/entity/Q161866">
             <persName>King Henry IV</persName>
           </person>
-          <person xml:id="Westmoreland_1H4">
+          <person xml:id="Westmoreland_1H4" ana="http://www.wikidata.org/entity/Q1972589">
             <persName>Earl of Westmoreland</persName>
           </person>
-          <person xml:id="Falstaff_1H4">
+          <person xml:id="Falstaff_1H4" ana="http://www.wikidata.org/entity/Q71125">
             <persName>Sir John Falstaff</persName>
           </person>
-          <person xml:id="HenryV_H5">
+          <person xml:id="HenryV_H5" ana="http://www.wikidata.org/entity/Q131581">
             <persName>Prince Hal</persName>
           </person>
-          <person xml:id="Poins_1H4">
+          <person xml:id="Poins_1H4" sex="MALE">
             <persName>Poins</persName>
           </person>
-          <person xml:id="Worcester_1H4">
+          <person xml:id="Worcester_1H4" ana="http://www.wikidata.org/entity/Q2082616">
             <persName>Earl of Worcester</persName>
           </person>
-          <person xml:id="Northumberland_R2">
+          <person xml:id="Northumberland_R2" ana="http://www.wikidata.org/entity/Q1398378">
             <persName>Earl of Northumberland</persName>
           </person>
-          <person xml:id="Hotspur_R2">
+          <person xml:id="Hotspur_R2" ana="http://www.wikidata.org/entity/Q471421">
             <persName>Hotspur</persName>
           </person>
-          <person xml:id="Blunt_1H4">
+          <person xml:id="Blunt_1H4" ana="http://www.wikidata.org/entity/Q7964324">
             <persName>Sir Walter Blunt</persName>
           </person>
-          <person xml:id="TRAVELERS.CARRIERS.1_1H4">
-            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
-          </person>
-          <person xml:id="Ostler_1H4">
-            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
-          </person>
-          <person xml:id="TRAVELERS.CARRIERS.2_1H4">
-            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
-          </person>
-          <person xml:id="Gadshill_1H4">
+          <personGrp xml:id="TRAVELERS.CARRIERS.1_1H4" sex="UNKNOWN">
+            <name>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</name>
+          </personGrp>
+          <personGrp xml:id="Ostler_1H4" sex="UNKNOWN">
+            <name>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</name>
+          </personGrp>
+          <personGrp xml:id="TRAVELERS.CARRIERS.2_1H4" sex="UNKNOWN">
+            <name>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</name>
+          </personGrp>
+          <person xml:id="Gadshill_1H4" sex="MALE">
             <persName>Gadshill</persName>
           </person>
-          <person xml:id="Chamberlain_1H4">
-            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
-          </person>
-          <person xml:id="Bardolph_1H4">
+          <personGrp xml:id="Chamberlain_1H4" sex="UNKNOWN">
+            <name>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</name>
+          </personGrp>
+          <person xml:id="Bardolph_1H4" ana="http://www.wikidata.org/entity/Q7787379">
             <persName>Bardolph</persName>
           </person>
-          <person xml:id="Peto_1H4">
+          <person xml:id="Peto_1H4" sex="MALE">
             <persName>Peto</persName>
           </person>
-          <person xml:id="TRAVELERS.GENTLEMEN.0.1_1H4">
-            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
-          </person>
-          <person xml:id="TRAVELERS.CARRIERS_1H4">
-            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
-          </person>
-          <person xml:id="TRAVELERS.GENTLEMEN_1H4">
-            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
-          </person>
-          <person xml:id="LadyPercy_1H4">
+          <personGrp xml:id="TRAVELERS.GENTLEMEN.0.1_1H4" sex="UNKNOWN">
+            <name>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</name>
+          </personGrp>
+          <personGrp xml:id="TRAVELERS.CARRIERS_1H4" sex="UNKNOWN">
+            <name>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</name>
+          </personGrp>
+          <personGrp xml:id="TRAVELERS.GENTLEMEN_1H4" sex="UNKNOWN">
+            <name>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</name>
+          </personGrp>
+          <person xml:id="LadyPercy_1H4" ana="http://www.wikidata.org/entity/Q5363245">
             <persName>Lady Percy</persName>
           </person>
-          <person xml:id="SERVANTS.HOTSPUR.1_1H4">
-            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
-          </person>
-          <person xml:id="DRAWERS.Francis_1H4">
+          <personGrp xml:id="SERVANTS.HOTSPUR.1_1H4" sex="UNKNOWN">
+            <name>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</name>
+          </personGrp>
+          <person xml:id="DRAWERS.Francis_1H4" sex="MALE">
             <persName>Francis</persName>
           </person>
-          <person xml:id="Vintner_1H4">
+          <person xml:id="Vintner_1H4" sex="MALE">
             <persName>Vintner</persName>
           </person>
-          <person xml:id="MistressQuickly_1H4">
+          <person xml:id="MistressQuickly_1H4" sex="FEMALE">
             <persName>Hostess</persName>
           </person>
-          <person xml:id="Sheriff_1H4">
-            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
-          </person>
-          <person xml:id="TRAVELERS.CARRIERS.X_1H4">
-            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
-          </person>
-          <person xml:id="Mortimer_1H4">
+          <personGrp xml:id="Sheriff_1H4" sex="UNKNOWN">
+            <name>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</name>
+          </personGrp>
+          <personGrp xml:id="TRAVELERS.CARRIERS.X_1H4" sex="UNKNOWN">
+            <name>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</name>
+          </personGrp>
+          <person xml:id="Mortimer_1H4" ana="http://www.wikidata.org/entity/Q3402270">
             <persName>Edmund Mortimer</persName>
           </person>
-          <person xml:id="Glendower_1H4">
+          <person xml:id="Glendower_1H4" ana="http://www.wikidata.org/entity/Q317279">
             <persName>Owen Glendower</persName>
           </person>
-          <person xml:id="Douglas_1H4">
+          <person xml:id="Douglas_1H4" ana="http://www.wikidata.org/entity/Q633144">
             <persName>Douglas</persName>
           </person>
-          <person xml:id="MESSENGERS.X_1H4">
-            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
-          </person>
-          <person xml:id="Vernon_1H4">
+          <personGrp xml:id="MESSENGERS.X_1H4" sex="UNKNOWN">
+            <name>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</name>
+          </personGrp>
+          <person xml:id="Vernon_1H4" ana="http://www.wikidata.org/entity/Q7329662">
             <persName>Sir Richard Vernon</persName>
           </person>
-          <person xml:id="Archbishop_1H4">
+          <person xml:id="Archbishop_1H4" ana="http://www.wikidata.org/entity/Q3431392">
             <persName>Archbishop</persName>
           </person>
-          <person xml:id="SirMichael_1H4">
+          <person xml:id="SirMichael_1H4" sex="MALE">
             <persName>Sir Michael</persName>
           </person>
-          <person xml:id="MESSENGERS.1_1H4">
-            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
-          </person>
-          <person xml:id="MESSENGERS.2_1H4">
-            <persName>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</persName>
-          </person>
-          <person xml:id="Bedford_H5">
+          <personGrp xml:id="MESSENGERS.1_1H4" sex="UNKNOWN">
+            <name>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</name>
+          </personGrp>
+          <personGrp xml:id="MESSENGERS.2_1H4" sex="UNKNOWN">
+            <name>Carriers, Ostlers, Chamberlain, Travelers, Sheriff, Servants, Lords, Attendants, Messengers, Soldiers</name>
+          </personGrp>
+          <person xml:id="Bedford_H5" sex="MALE">
             <persName>Lord John of Lancaster</persName>
           </person>
         </listPerson>

--- a/tei/henry-iv-part-ii.xml
+++ b/tei/henry-iv-part-ii.xml
@@ -88,155 +88,155 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Chorus_2H4">
+          <person xml:id="Chorus_2H4" sex="MALE">
             <persName>Rumor</persName>
           </person>
-          <person xml:id="LordBardolph_2H4">
+          <person xml:id="LordBardolph_2H4" sex="MALE">
             <persName>Lord Bardolph</persName>
           </person>
-          <person xml:id="Porter_2H4">
-            <persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName>
-          </person>
-          <person xml:id="Northumberland_R2">
+          <personGrp xml:id="Porter_2H4" sex="UNKNOWN">
+            <name>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</name>
+          </personGrp>
+          <person xml:id="Northumberland_R2" sex="MALE">
             <persName>Earl of Northumberland</persName>
           </person>
-          <person xml:id="Travers_2H4">
+          <person xml:id="Travers_2H4" sex="MALE">
             <persName>Travers</persName>
           </person>
-          <person xml:id="Morton_2H4">
+          <person xml:id="Morton_2H4" sex="MALE">
             <persName>Morton</persName>
           </person>
-          <person xml:id="Falstaff_1H4">
+          <person xml:id="Falstaff_1H4" sex="MALE">
             <persName>Sir John Falstaff</persName>
           </person>
-          <person xml:id="SERVANTS.FALSTAFF.1_2H4">
+          <person xml:id="SERVANTS.FALSTAFF.1_2H4" sex="FEMALE">
             <persName>Falstaff’s Page</persName>
           </person>
-          <person xml:id="ChiefJustice_2H4">
+          <person xml:id="ChiefJustice_2H4" sex="MALE">
             <persName>Lord Chief Justice</persName>
           </person>
-          <person xml:id="SERVANTS.CHIEFJUSTICE.1_2H4">
-            <persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName>
-          </person>
-          <person xml:id="Archbishop_1H4">
+          <personGrp xml:id="SERVANTS.CHIEFJUSTICE.1_2H4" sex="UNKNOWN">
+            <name>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</name>
+          </personGrp>
+          <person xml:id="Archbishop_1H4" sex="MALE">
             <persName>Archbishop</persName>
           </person>
-          <person xml:id="Mowbray_2H4">
+          <person xml:id="Mowbray_2H4" sex="MALE">
             <persName>Lord Mowbray</persName>
           </person>
-          <person xml:id="Hastings_2H4">
+          <person xml:id="Hastings_2H4" sex="MALE">
             <persName>Lord Hastings</persName>
           </person>
-          <person xml:id="MistressQuickly_1H4">
+          <person xml:id="MistressQuickly_1H4" sex="FEMALE">
             <persName>Hostess</persName>
           </person>
-          <person xml:id="OFFICERS.Fang_2H4">
+          <person xml:id="OFFICERS.Fang_2H4" sex="MALE">
             <persName>Fang</persName>
           </person>
-          <person xml:id="OFFICERS.Snare_2H4">
+          <person xml:id="OFFICERS.Snare_2H4" sex="MALE">
             <persName>Snare</persName>
           </person>
-          <person xml:id="MESSENGERS.Gower_2H4">
+          <person xml:id="MESSENGERS.Gower_2H4" sex="MALE">
             <persName>Gower</persName>
           </person>
-          <person xml:id="HenryV_H5">
+          <person xml:id="HenryV_H5" ana="http://www.wikidata.org/entity/Q131581">
             <persName>Prince Hal King Henry V</persName>
             <persName>Prince Hal King Henry V</persName>
           </person>
-          <person xml:id="Poins_1H4">
+          <person xml:id="Poins_1H4" sex="MALE">
             <persName>Poins</persName>
           </person>
-          <person xml:id="Bardolph_1H4">
+          <person xml:id="Bardolph_1H4" sex="MALE">
             <persName>Bardolph</persName>
           </person>
-          <person xml:id="LadyNorthumberland_2H4">
+          <person xml:id="LadyNorthumberland_2H4" sex="FEMALE">
             <persName>Northumberland’s wife</persName>
           </person>
-          <person xml:id="LadyPercy_1H4">
+          <person xml:id="LadyPercy_1H4" sex="FEMALE">
             <persName>Lady Percy</persName>
           </person>
-          <person xml:id="DRAWERS.Francis_1H4">
-            <persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName>
-          </person>
-          <person xml:id="DRAWERS.1_2H4">
-            <persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName>
-          </person>
-          <person xml:id="DRAWERS.Will_2H4">
-            <persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName>
-          </person>
-          <person xml:id="DollTearsheet_2H4">
+          <personGrp xml:id="DRAWERS.Francis_1H4" sex="UNKNOWN">
+            <name>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</name>
+          </personGrp>
+          <personGrp xml:id="DRAWERS.1_2H4" sex="UNKNOWN">
+            <name>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</name>
+          </personGrp>
+          <personGrp xml:id="DRAWERS.Will_2H4" sex="UNKNOWN">
+            <name>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</name>
+          </personGrp>
+          <person xml:id="DollTearsheet_2H4" sex="FEMALE">
             <persName>Doll Tearsheet</persName>
           </person>
-          <person xml:id="DRAWERS.X_2H4">
-            <persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName>
-          </person>
-          <person xml:id="Pistol_2H4">
+          <personGrp xml:id="DRAWERS.X_2H4" sex="UNKNOWN">
+            <name>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</name>
+          </personGrp>
+          <person xml:id="Pistol_2H4" sex="MALE">
             <persName>Pistol</persName>
           </person>
-          <person xml:id="Peto_1H4">
+          <person xml:id="Peto_1H4" sex="MALE">
             <persName>Peto</persName>
           </person>
-          <person xml:id="HenryIV_1H4">
+          <person xml:id="HenryIV_1H4" ana="http://www.wikidata.org/entity/Q936976">
             <persName>King Henry IV</persName>
           </person>
-          <person xml:id="Warwick_2H4">
+          <person xml:id="Warwick_2H4" sex="MALE">
             <persName>Earl of Warwick</persName>
           </person>
-          <person xml:id="Shallow_2H4">
+          <person xml:id="Shallow_2H4" sex="MALE">
             <persName>Justice Robert Shallow</persName>
           </person>
-          <person xml:id="Silence_2H4">
+          <person xml:id="Silence_2H4" sex="MALE">
             <persName>Justice Silence</persName>
           </person>
-          <person xml:id="Mouldy_2H4">
+          <person xml:id="Mouldy_2H4" sex="MALE">
             <persName>Mouldy</persName>
           </person>
-          <person xml:id="Shadow_2H4">
+          <person xml:id="Shadow_2H4" sex="MALE">
             <persName>Shadow</persName>
           </person>
-          <person xml:id="Wart_2H4">
+          <person xml:id="Wart_2H4" sex="MALE">
             <persName>Wart</persName>
           </person>
-          <person xml:id="Feeble_2H4">
+          <person xml:id="Feeble_2H4" sex="MALE">
             <persName>Feeble</persName>
           </person>
-          <person xml:id="Bullcalf_2H4">
+          <person xml:id="Bullcalf_2H4" sex="MALE">
             <persName>Bullcalf</persName>
           </person>
-          <person xml:id="MESSENGERS.1_2H4">
-            <persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName>
-          </person>
-          <person xml:id="Westmoreland_1H4">
+          <personGrp xml:id="MESSENGERS.1_2H4" sex="UNKNOWN">
+            <name>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</name>
+          </personGrp>
+          <person xml:id="Westmoreland_1H4" sex="MALE">
             <persName>Earl of Westmoreland</persName>
           </person>
-          <person xml:id="Bedford_H5">
+          <person xml:id="Bedford_H5" ana="http://www.wikidata.org/entity/Q348441">
             <persName>John of Lancaster</persName>
           </person>
-          <person xml:id="Colevile_2H4">
+          <person xml:id="Colevile_2H4" sex="MALE">
             <persName>Sir John Colevile</persName>
           </person>
-          <person xml:id="Gloucester_2H4">
+          <person xml:id="Gloucester_2H4" ana="http://www.wikidata.org/entity/Q447541">
             <persName>Humphrey of Gloucester</persName>
           </person>
-          <person xml:id="Clarence_2H4">
+          <person xml:id="Clarence_2H4" ana="http://www.wikidata.org/entity/Q511869">
             <persName>Thomas of Clarence</persName>
           </person>
-          <person xml:id="Harcourt_2H4">
+          <person xml:id="Harcourt_2H4" sex="MALE">
             <persName>Harcourt</persName>
           </person>
-          <person xml:id="Davy_2H4">
+          <person xml:id="Davy_2H4" sex="MALE">
             <persName>Davy</persName>
           </person>
-          <person xml:id="BEADLES.0.1_2H4">
-            <persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName>
-          </person>
-          <person xml:id="GROOMS.1_2H4">
-            <persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName>
-          </person>
-          <person xml:id="GROOMS.2_2H4">
-            <persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName>
-          </person>
-          <person xml:id="Epilogue_2H4">
+          <personGrp xml:id="BEADLES.0.1_2H4" sex="UNKNOWN">
+            <name>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</name>
+          </personGrp>
+          <personGrp xml:id="GROOMS.1_2H4" sex="UNKNOWN">
+            <name>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</name>
+          </personGrp>
+          <personGrp xml:id="GROOMS.2_2H4" sex="UNKNOWN">
+            <name>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</name>
+          </personGrp>
+          <person xml:id="Epilogue_2H4" sex="UNKNOWN">
             <persName>Epilogue</persName>
           </person>
         </listPerson>

--- a/tei/henry-iv-part-ii.xml
+++ b/tei/henry-iv-part-ii.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,162 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Chorus_2H4"><persName>Rumor</persName></person><person xml:id="LordBardolph_2H4"><persName>Lord Bardolph</persName></person><person xml:id="Porter_2H4"><persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName></person><person xml:id="Northumberland_R2"><persName>Earl of Northumberland</persName></person><person xml:id="Travers_2H4"><persName>Travers</persName></person><person xml:id="Morton_2H4"><persName>Morton</persName></person><person xml:id="Falstaff_1H4"><persName>Sir John Falstaff</persName></person><person xml:id="SERVANTS.FALSTAFF.1_2H4"><persName>Falstaff’s Page</persName></person><person xml:id="ChiefJustice_2H4"><persName>Lord Chief Justice</persName></person><person xml:id="SERVANTS.CHIEFJUSTICE.1_2H4"><persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName></person><person xml:id="Archbishop_1H4"><persName>Archbishop</persName></person><person xml:id="Mowbray_2H4"><persName>Lord Mowbray</persName></person><person xml:id="Hastings_2H4"><persName>Lord Hastings</persName></person><person xml:id="MistressQuickly_1H4"><persName>Hostess</persName></person><person xml:id="OFFICERS.Fang_2H4"><persName>Fang</persName></person><person xml:id="OFFICERS.Snare_2H4"><persName>Snare</persName></person><person xml:id="MESSENGERS.Gower_2H4"><persName>Gower</persName></person><person xml:id="HenryV_H5"><persName>Prince Hal King Henry V</persName><persName>Prince Hal King Henry V</persName></person><person xml:id="Poins_1H4"><persName>Poins</persName></person><person xml:id="Bardolph_1H4"><persName>Bardolph</persName></person><person xml:id="LadyNorthumberland_2H4"><persName>Northumberland’s wife</persName></person><person xml:id="LadyPercy_1H4"><persName>Lady Percy</persName></person><person xml:id="DRAWERS.Francis_1H4"><persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName></person><person xml:id="DRAWERS.1_2H4"><persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName></person><person xml:id="DRAWERS.Will_2H4"><persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName></person><person xml:id="DollTearsheet_2H4"><persName>Doll Tearsheet</persName></person><person xml:id="DRAWERS.X_2H4"><persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName></person><person xml:id="Pistol_2H4"><persName>Pistol</persName></person><person xml:id="Peto_1H4"><persName>Peto</persName></person><person xml:id="HenryIV_1H4"><persName>King Henry IV</persName></person><person xml:id="Warwick_2H4"><persName>Earl of Warwick</persName></person><person xml:id="Shallow_2H4"><persName>Justice Robert Shallow</persName></person><person xml:id="Silence_2H4"><persName>Justice Silence</persName></person><person xml:id="Mouldy_2H4"><persName>Mouldy</persName></person><person xml:id="Shadow_2H4"><persName>Shadow</persName></person><person xml:id="Wart_2H4"><persName>Wart</persName></person><person xml:id="Feeble_2H4"><persName>Feeble</persName></person><person xml:id="Bullcalf_2H4"><persName>Bullcalf</persName></person><person xml:id="MESSENGERS.1_2H4"><persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName></person><person xml:id="Westmoreland_1H4"><persName>Earl of Westmoreland</persName></person><person xml:id="Bedford_H5"><persName>John of Lancaster</persName></person><person xml:id="Colevile_2H4"><persName>Sir John Colevile</persName></person><person xml:id="Gloucester_2H4"><persName>Humphrey of Gloucester</persName></person><person xml:id="Clarence_2H4"><persName>Thomas of Clarence</persName></person><person xml:id="Harcourt_2H4"><persName>Harcourt</persName></person><person xml:id="Davy_2H4"><persName>Davy</persName></person><person xml:id="BEADLES.0.1_2H4"><persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName></person><person xml:id="GROOMS.1_2H4"><persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName></person><person xml:id="GROOMS.2_2H4"><persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName></person><person xml:id="Epilogue_2H4"><persName>Epilogue</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Chorus_2H4">
+            <persName>Rumor</persName>
+          </person>
+          <person xml:id="LordBardolph_2H4">
+            <persName>Lord Bardolph</persName>
+          </person>
+          <person xml:id="Porter_2H4">
+            <persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName>
+          </person>
+          <person xml:id="Northumberland_R2">
+            <persName>Earl of Northumberland</persName>
+          </person>
+          <person xml:id="Travers_2H4">
+            <persName>Travers</persName>
+          </person>
+          <person xml:id="Morton_2H4">
+            <persName>Morton</persName>
+          </person>
+          <person xml:id="Falstaff_1H4">
+            <persName>Sir John Falstaff</persName>
+          </person>
+          <person xml:id="SERVANTS.FALSTAFF.1_2H4">
+            <persName>Falstaff’s Page</persName>
+          </person>
+          <person xml:id="ChiefJustice_2H4">
+            <persName>Lord Chief Justice</persName>
+          </person>
+          <person xml:id="SERVANTS.CHIEFJUSTICE.1_2H4">
+            <persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName>
+          </person>
+          <person xml:id="Archbishop_1H4">
+            <persName>Archbishop</persName>
+          </person>
+          <person xml:id="Mowbray_2H4">
+            <persName>Lord Mowbray</persName>
+          </person>
+          <person xml:id="Hastings_2H4">
+            <persName>Lord Hastings</persName>
+          </person>
+          <person xml:id="MistressQuickly_1H4">
+            <persName>Hostess</persName>
+          </person>
+          <person xml:id="OFFICERS.Fang_2H4">
+            <persName>Fang</persName>
+          </person>
+          <person xml:id="OFFICERS.Snare_2H4">
+            <persName>Snare</persName>
+          </person>
+          <person xml:id="MESSENGERS.Gower_2H4">
+            <persName>Gower</persName>
+          </person>
+          <person xml:id="HenryV_H5">
+            <persName>Prince Hal King Henry V</persName>
+            <persName>Prince Hal King Henry V</persName>
+          </person>
+          <person xml:id="Poins_1H4">
+            <persName>Poins</persName>
+          </person>
+          <person xml:id="Bardolph_1H4">
+            <persName>Bardolph</persName>
+          </person>
+          <person xml:id="LadyNorthumberland_2H4">
+            <persName>Northumberland’s wife</persName>
+          </person>
+          <person xml:id="LadyPercy_1H4">
+            <persName>Lady Percy</persName>
+          </person>
+          <person xml:id="DRAWERS.Francis_1H4">
+            <persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName>
+          </person>
+          <person xml:id="DRAWERS.1_2H4">
+            <persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName>
+          </person>
+          <person xml:id="DRAWERS.Will_2H4">
+            <persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName>
+          </person>
+          <person xml:id="DollTearsheet_2H4">
+            <persName>Doll Tearsheet</persName>
+          </person>
+          <person xml:id="DRAWERS.X_2H4">
+            <persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName>
+          </person>
+          <person xml:id="Pistol_2H4">
+            <persName>Pistol</persName>
+          </person>
+          <person xml:id="Peto_1H4">
+            <persName>Peto</persName>
+          </person>
+          <person xml:id="HenryIV_1H4">
+            <persName>King Henry IV</persName>
+          </person>
+          <person xml:id="Warwick_2H4">
+            <persName>Earl of Warwick</persName>
+          </person>
+          <person xml:id="Shallow_2H4">
+            <persName>Justice Robert Shallow</persName>
+          </person>
+          <person xml:id="Silence_2H4">
+            <persName>Justice Silence</persName>
+          </person>
+          <person xml:id="Mouldy_2H4">
+            <persName>Mouldy</persName>
+          </person>
+          <person xml:id="Shadow_2H4">
+            <persName>Shadow</persName>
+          </person>
+          <person xml:id="Wart_2H4">
+            <persName>Wart</persName>
+          </person>
+          <person xml:id="Feeble_2H4">
+            <persName>Feeble</persName>
+          </person>
+          <person xml:id="Bullcalf_2H4">
+            <persName>Bullcalf</persName>
+          </person>
+          <person xml:id="MESSENGERS.1_2H4">
+            <persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName>
+          </person>
+          <person xml:id="Westmoreland_1H4">
+            <persName>Earl of Westmoreland</persName>
+          </person>
+          <person xml:id="Bedford_H5">
+            <persName>John of Lancaster</persName>
+          </person>
+          <person xml:id="Colevile_2H4">
+            <persName>Sir John Colevile</persName>
+          </person>
+          <person xml:id="Gloucester_2H4">
+            <persName>Humphrey of Gloucester</persName>
+          </person>
+          <person xml:id="Clarence_2H4">
+            <persName>Thomas of Clarence</persName>
+          </person>
+          <person xml:id="Harcourt_2H4">
+            <persName>Harcourt</persName>
+          </person>
+          <person xml:id="Davy_2H4">
+            <persName>Davy</persName>
+          </person>
+          <person xml:id="BEADLES.0.1_2H4">
+            <persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName>
+          </person>
+          <person xml:id="GROOMS.1_2H4">
+            <persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName>
+          </person>
+          <person xml:id="GROOMS.2_2H4">
+            <persName>Drawers, Musicians, Beadles, Grooms, Messenger, Soldiers, Lords, Attendants, Porter, Servants</persName>
+          </person>
+          <person xml:id="Epilogue_2H4">
+            <persName>Epilogue</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/henry-v.xml
+++ b/tei/henry-v.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,155 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Chorus_H5"><persName>Chorus</persName></person><person xml:id="BishopOfCanterbury_H5"><persName>Bishop of Canterbury</persName></person><person xml:id="BishopOfEly_H5"><persName>Bishop of Ely</persName></person><person xml:id="HenryV_H5"><persName>Henry V, King of England</persName></person><person xml:id="Exeter_H5"><persName>Thomas, Duke of Exeter</persName></person><person xml:id="Westmoreland_1H4"><persName>Earl of Westmoreland</persName></person><person xml:id="AMBASSADORS.0.1_H5"><persName>AMBASSADORS.0.1_H5</persName></person><person xml:id="Bardolph_1H4"><persName>Bardolph</persName></person><person xml:id="Nym_H5"><persName>Nym</persName></person><person xml:id="Pistol_2H4"><persName>Pistol</persName></person><person xml:id="MistressQuickly_1H4"><persName>Hostess Quickly</persName></person><person xml:id="Boy_H5"><persName>Boy</persName></person><person xml:id="Bedford_H5"><persName>John, Duke of Bedford</persName></person><person xml:id="Scroop_H5"><persName>Lord Scroop of Masham</persName></person><person xml:id="Cambridge_H5"><persName>Earl of Cambridge</persName></person><person xml:id="Grey_H5"><persName>Sir Thomas Grey</persName></person><person xml:id="KingOfFrance_H5"><persName>King of France</persName></person><person xml:id="Dauphin_H5"><persName>Dauphin</persName></person><person xml:id="Constable_H5"><persName>Constable of France</persName></person><person xml:id="MESSENGERS.X.1_H5"><persName>Lords, Attendants, Soldiers, French Prisoners, Messengers</persName></person><person xml:id="Fluellen_H5"><persName>Captain Fluellen</persName></person><person xml:id="Gower_H5"><persName>Captain Gower</persName></person><person xml:id="Jamy_H5"><persName>Captain Jamy</persName></person><person xml:id="MacMorris_H5"><persName>Captain MacMorris</persName></person><person xml:id="Governor_H5"><persName>Governor_H5</persName></person><person xml:id="Katherine_H5"><persName>Katherine</persName></person><person xml:id="Alice_H5"><persName>Alice</persName></person><person xml:id="Brittany_H5"><persName>Duke of Brittany</persName></person><person xml:id="Montjoy_H5"><persName>Montjoy</persName></person><person xml:id="Gloucester_2H4"><persName>Humphrey, Duke of Gloucester</persName></person><person xml:id="Orleans_H5"><persName>Duke of Orléans</persName></person><person xml:id="Rambures_H5"><persName>Lord Rambures</persName></person><person xml:id="MESSENGERS.X.2_H5"><persName>Lords, Attendants, Soldiers, French Prisoners, Messengers</persName></person><person xml:id="Erpingham_H5"><persName>Sir Thomas Erpingham</persName></person><person xml:id="SOLDIERS.ENGLISH.Court_H5"><persName>Alexander Court</persName></person><person xml:id="SOLDIERS.ENGLISH.Bates_H5"><persName>John Bates</persName></person><person xml:id="SOLDIERS.ENGLISH.Williams_H5"><persName>Michael Williams</persName></person><person xml:id="MESSENGERS.X.3_H5"><persName>Lords, Attendants, Soldiers, French Prisoners, Messengers</persName></person><person xml:id="Grandpre_H5"><persName>Lord Grandpré</persName></person><person xml:id="Salisbury_H5"><persName>Earl of Salisbury</persName></person><person xml:id="York_H5"><persName>Duke of York</persName></person><person xml:id="SOLDIERS.FRENCH.LeFer_H5"><persName>Monsieur Le Fer</persName></person><person xml:id="Bourbon_H5"><persName>Duke of Bourbon</persName></person><person xml:id="Warwick_2H4"><persName>Earl of Warwick</persName></person><person xml:id="HERALDS.1_H5"><persName>HERALDS.1_H5</persName></person><person xml:id="QueenOfFrance_H5"><persName>Queen Isabel of France</persName></person><person xml:id="Burgundy_H5"><persName>Duke of Burgundy</persName></person><person xml:id="ATTENDANTS.ENGLISH_H5"><persName>Lords, Attendants, Soldiers, French Prisoners, Messengers</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Chorus_H5">
+            <persName>Chorus</persName>
+          </person>
+          <person xml:id="BishopOfCanterbury_H5">
+            <persName>Bishop of Canterbury</persName>
+          </person>
+          <person xml:id="BishopOfEly_H5">
+            <persName>Bishop of Ely</persName>
+          </person>
+          <person xml:id="HenryV_H5">
+            <persName>Henry V, King of England</persName>
+          </person>
+          <person xml:id="Exeter_H5">
+            <persName>Thomas, Duke of Exeter</persName>
+          </person>
+          <person xml:id="Westmoreland_1H4">
+            <persName>Earl of Westmoreland</persName>
+          </person>
+          <person xml:id="AMBASSADORS.0.1_H5">
+            <persName>AMBASSADORS.0.1_H5</persName>
+          </person>
+          <person xml:id="Bardolph_1H4">
+            <persName>Bardolph</persName>
+          </person>
+          <person xml:id="Nym_H5">
+            <persName>Nym</persName>
+          </person>
+          <person xml:id="Pistol_2H4">
+            <persName>Pistol</persName>
+          </person>
+          <person xml:id="MistressQuickly_1H4">
+            <persName>Hostess Quickly</persName>
+          </person>
+          <person xml:id="Boy_H5">
+            <persName>Boy</persName>
+          </person>
+          <person xml:id="Bedford_H5">
+            <persName>John, Duke of Bedford</persName>
+          </person>
+          <person xml:id="Scroop_H5">
+            <persName>Lord Scroop of Masham</persName>
+          </person>
+          <person xml:id="Cambridge_H5">
+            <persName>Earl of Cambridge</persName>
+          </person>
+          <person xml:id="Grey_H5">
+            <persName>Sir Thomas Grey</persName>
+          </person>
+          <person xml:id="KingOfFrance_H5">
+            <persName>King of France</persName>
+          </person>
+          <person xml:id="Dauphin_H5">
+            <persName>Dauphin</persName>
+          </person>
+          <person xml:id="Constable_H5">
+            <persName>Constable of France</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.1_H5">
+            <persName>Lords, Attendants, Soldiers, French Prisoners, Messengers</persName>
+          </person>
+          <person xml:id="Fluellen_H5">
+            <persName>Captain Fluellen</persName>
+          </person>
+          <person xml:id="Gower_H5">
+            <persName>Captain Gower</persName>
+          </person>
+          <person xml:id="Jamy_H5">
+            <persName>Captain Jamy</persName>
+          </person>
+          <person xml:id="MacMorris_H5">
+            <persName>Captain MacMorris</persName>
+          </person>
+          <person xml:id="Governor_H5">
+            <persName>Governor_H5</persName>
+          </person>
+          <person xml:id="Katherine_H5">
+            <persName>Katherine</persName>
+          </person>
+          <person xml:id="Alice_H5">
+            <persName>Alice</persName>
+          </person>
+          <person xml:id="Brittany_H5">
+            <persName>Duke of Brittany</persName>
+          </person>
+          <person xml:id="Montjoy_H5">
+            <persName>Montjoy</persName>
+          </person>
+          <person xml:id="Gloucester_2H4">
+            <persName>Humphrey, Duke of Gloucester</persName>
+          </person>
+          <person xml:id="Orleans_H5">
+            <persName>Duke of Orléans</persName>
+          </person>
+          <person xml:id="Rambures_H5">
+            <persName>Lord Rambures</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.2_H5">
+            <persName>Lords, Attendants, Soldiers, French Prisoners, Messengers</persName>
+          </person>
+          <person xml:id="Erpingham_H5">
+            <persName>Sir Thomas Erpingham</persName>
+          </person>
+          <person xml:id="SOLDIERS.ENGLISH.Court_H5">
+            <persName>Alexander Court</persName>
+          </person>
+          <person xml:id="SOLDIERS.ENGLISH.Bates_H5">
+            <persName>John Bates</persName>
+          </person>
+          <person xml:id="SOLDIERS.ENGLISH.Williams_H5">
+            <persName>Michael Williams</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.3_H5">
+            <persName>Lords, Attendants, Soldiers, French Prisoners, Messengers</persName>
+          </person>
+          <person xml:id="Grandpre_H5">
+            <persName>Lord Grandpré</persName>
+          </person>
+          <person xml:id="Salisbury_H5">
+            <persName>Earl of Salisbury</persName>
+          </person>
+          <person xml:id="York_H5">
+            <persName>Duke of York</persName>
+          </person>
+          <person xml:id="SOLDIERS.FRENCH.LeFer_H5">
+            <persName>Monsieur Le Fer</persName>
+          </person>
+          <person xml:id="Bourbon_H5">
+            <persName>Duke of Bourbon</persName>
+          </person>
+          <person xml:id="Warwick_2H4">
+            <persName>Earl of Warwick</persName>
+          </person>
+          <person xml:id="HERALDS.1_H5">
+            <persName>HERALDS.1_H5</persName>
+          </person>
+          <person xml:id="QueenOfFrance_H5">
+            <persName>Queen Isabel of France</persName>
+          </person>
+          <person xml:id="Burgundy_H5">
+            <persName>Duke of Burgundy</persName>
+          </person>
+          <person xml:id="ATTENDANTS.ENGLISH_H5">
+            <persName>Lords, Attendants, Soldiers, French Prisoners, Messengers</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/henry-v.xml
+++ b/tei/henry-v.xml
@@ -88,150 +88,150 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Chorus_H5">
-            <persName>Chorus</persName>
-          </person>
-          <person xml:id="BishopOfCanterbury_H5">
+          <personGrp xml:id="Chorus_H5" sex="UNKNOWN">
+            <name>Chorus</name>
+          </personGrp>
+          <person xml:id="BishopOfCanterbury_H5" ana="http://www.wikidata.org/entity/Q2376957">
             <persName>Bishop of Canterbury</persName>
           </person>
-          <person xml:id="BishopOfEly_H5">
+          <person xml:id="BishopOfEly_H5" ana="http://www.wikidata.org/entity/Q6233619">
             <persName>Bishop of Ely</persName>
           </person>
-          <person xml:id="HenryV_H5">
+          <person xml:id="HenryV_H5" ana="http://www.wikidata.org/entity/Q131581">
             <persName>Henry V, King of England</persName>
           </person>
-          <person xml:id="Exeter_H5">
+          <person xml:id="Exeter_H5" ana="http://www.wikidata.org/entity/Q660630">
             <persName>Thomas, Duke of Exeter</persName>
           </person>
-          <person xml:id="Westmoreland_1H4">
+          <person xml:id="Westmoreland_1H4" ana="http://www.wikidata.org/entity/Q1972589">
             <persName>Earl of Westmoreland</persName>
           </person>
-          <person xml:id="AMBASSADORS.0.1_H5">
-            <persName>AMBASSADORS.0.1_H5</persName>
-          </person>
-          <person xml:id="Bardolph_1H4">
+          <personGrp xml:id="AMBASSADORS.0.1_H5" sex="UNKNOWN">
+            <name>AMBASSADORS.0.1_H5</name>
+          </personGrp>
+          <person xml:id="Bardolph_1H4" sex="MALE">
             <persName>Bardolph</persName>
           </person>
-          <person xml:id="Nym_H5">
+          <person xml:id="Nym_H5" sex="MALE">
             <persName>Nym</persName>
           </person>
-          <person xml:id="Pistol_2H4">
+          <person xml:id="Pistol_2H4" sex="MALE">
             <persName>Pistol</persName>
           </person>
-          <person xml:id="MistressQuickly_1H4">
+          <person xml:id="MistressQuickly_1H4" sex="FEMALE">
             <persName>Hostess Quickly</persName>
           </person>
-          <person xml:id="Boy_H5">
+          <person xml:id="Boy_H5" sex="MALE">
             <persName>Boy</persName>
           </person>
-          <person xml:id="Bedford_H5">
+          <person xml:id="Bedford_H5" ana="http://www.wikidata.org/entity/Q348441">
             <persName>John, Duke of Bedford</persName>
           </person>
-          <person xml:id="Scroop_H5">
+          <person xml:id="Scroop_H5" ana="http://www.wikidata.org/entity/Q1607250">
             <persName>Lord Scroop of Masham</persName>
           </person>
-          <person xml:id="Cambridge_H5">
+          <person xml:id="Cambridge_H5" ana="http://www.wikidata.org/entity/Q469002">
             <persName>Earl of Cambridge</persName>
           </person>
-          <person xml:id="Grey_H5">
+          <person xml:id="Grey_H5" sex="MALE">
             <persName>Sir Thomas Grey</persName>
           </person>
-          <person xml:id="KingOfFrance_H5">
+          <person xml:id="KingOfFrance_H5" ana="http://www.wikidata.org/entity/Q160349">
             <persName>King of France</persName>
           </person>
-          <person xml:id="Dauphin_H5">
+          <person xml:id="Dauphin_H5" ana="http://www.wikidata.org/entity/Q1347131">
             <persName>Dauphin</persName>
           </person>
-          <person xml:id="Constable_H5">
+          <person xml:id="Constable_H5" ana="http://www.wikidata.org/entity/Q626829">
             <persName>Constable of France</persName>
           </person>
-          <person xml:id="MESSENGERS.X.1_H5">
-            <persName>Lords, Attendants, Soldiers, French Prisoners, Messengers</persName>
-          </person>
-          <person xml:id="Fluellen_H5">
+          <personGrp xml:id="MESSENGERS.X.1_H5" sex="UNKNOWN">
+            <name>Lords, Attendants, Soldiers, French Prisoners, Messengers</name>
+          </personGrp>
+          <person xml:id="Fluellen_H5" sex="MALE">
             <persName>Captain Fluellen</persName>
           </person>
-          <person xml:id="Gower_H5">
+          <person xml:id="Gower_H5" sex="MALE">
             <persName>Captain Gower</persName>
           </person>
-          <person xml:id="Jamy_H5">
+          <person xml:id="Jamy_H5" sex="MALE">
             <persName>Captain Jamy</persName>
           </person>
-          <person xml:id="MacMorris_H5">
+          <person xml:id="MacMorris_H5" sex="MALE">
             <persName>Captain MacMorris</persName>
           </person>
-          <person xml:id="Governor_H5">
+          <person xml:id="Governor_H5" sex="MALE">
             <persName>Governor_H5</persName>
           </person>
-          <person xml:id="Katherine_H5">
+          <person xml:id="Katherine_H5" ana="http://www.wikidata.org/entity/Q229192">
             <persName>Katherine</persName>
           </person>
-          <person xml:id="Alice_H5">
+          <person xml:id="Alice_H5" sex="FEMALE">
             <persName>Alice</persName>
           </person>
-          <person xml:id="Brittany_H5">
+          <person xml:id="Brittany_H5" ana="http://www.wikidata.org/entity/Q454013">
             <persName>Duke of Brittany</persName>
           </person>
-          <person xml:id="Montjoy_H5">
+          <person xml:id="Montjoy_H5" sex="MALE">
             <persName>Montjoy</persName>
           </person>
-          <person xml:id="Gloucester_2H4">
+          <person xml:id="Gloucester_2H4" ana="http://www.wikidata.org/entity/Q447541">
             <persName>Humphrey, Duke of Gloucester</persName>
           </person>
-          <person xml:id="Orleans_H5">
+          <person xml:id="Orleans_H5" ana="http://www.wikidata.org/entity/Q310146">
             <persName>Duke of Orléans</persName>
           </person>
-          <person xml:id="Rambures_H5">
+          <person xml:id="Rambures_H5" ana="http://www.wikidata.org/entity/Q3019053">
             <persName>Lord Rambures</persName>
           </person>
-          <person xml:id="MESSENGERS.X.2_H5">
-            <persName>Lords, Attendants, Soldiers, French Prisoners, Messengers</persName>
-          </person>
-          <person xml:id="Erpingham_H5">
+          <personGrp xml:id="MESSENGERS.X.2_H5" sex="UNKNOWN">
+            <name>Lords, Attendants, Soldiers, French Prisoners, Messengers</name>
+          </personGrp>
+          <person xml:id="Erpingham_H5" ana="http://www.wikidata.org/entity/Q446018">
             <persName>Sir Thomas Erpingham</persName>
           </person>
-          <person xml:id="SOLDIERS.ENGLISH.Court_H5">
+          <person xml:id="SOLDIERS.ENGLISH.Court_H5" sex="MALE">
             <persName>Alexander Court</persName>
           </person>
-          <person xml:id="SOLDIERS.ENGLISH.Bates_H5">
+          <person xml:id="SOLDIERS.ENGLISH.Bates_H5" sex="MALE">
             <persName>John Bates</persName>
           </person>
-          <person xml:id="SOLDIERS.ENGLISH.Williams_H5">
+          <person xml:id="SOLDIERS.ENGLISH.Williams_H5" sex="MALE">
             <persName>Michael Williams</persName>
           </person>
-          <person xml:id="MESSENGERS.X.3_H5">
-            <persName>Lords, Attendants, Soldiers, French Prisoners, Messengers</persName>
-          </person>
-          <person xml:id="Grandpre_H5">
+          <personGrp xml:id="MESSENGERS.X.3_H5" sex="UNKNOWN">
+            <name>Lords, Attendants, Soldiers, French Prisoners, Messengers</name>
+          </personGrp>
+          <person xml:id="Grandpre_H5" sex="MALE">
             <persName>Lord Grandpré</persName>
           </person>
-          <person xml:id="Salisbury_H5">
+          <person xml:id="Salisbury_H5" ana="http://www.wikidata.org/entity/Q1000874">
             <persName>Earl of Salisbury</persName>
           </person>
-          <person xml:id="York_H5">
+          <person xml:id="York_H5" ana="http://www.wikidata.org/entity/Q452639">
             <persName>Duke of York</persName>
           </person>
-          <person xml:id="SOLDIERS.FRENCH.LeFer_H5">
+          <person xml:id="SOLDIERS.FRENCH.LeFer_H5" sex="MALE">
             <persName>Monsieur Le Fer</persName>
           </person>
-          <person xml:id="Bourbon_H5">
+          <person xml:id="Bourbon_H5" ana="http://www.wikidata.org/entity/Q724225">
             <persName>Duke of Bourbon</persName>
           </person>
-          <person xml:id="Warwick_2H4">
+          <person xml:id="Warwick_2H4" ana="http://www.wikidata.org/entity/Q592988">
             <persName>Earl of Warwick</persName>
           </person>
-          <person xml:id="HERALDS.1_H5">
-            <persName>HERALDS.1_H5</persName>
-          </person>
-          <person xml:id="QueenOfFrance_H5">
+          <personGrp xml:id="HERALDS.1_H5" sex="UNKNOWN">
+            <name>HERALDS.1_H5</name>
+          </personGrp>
+          <person xml:id="QueenOfFrance_H5" ana="http://www.wikidata.org/entity/Q154064">
             <persName>Queen Isabel of France</persName>
           </person>
-          <person xml:id="Burgundy_H5">
+          <person xml:id="Burgundy_H5" ana="http://www.wikidata.org/entity/Q298901">
             <persName>Duke of Burgundy</persName>
           </person>
-          <person xml:id="ATTENDANTS.ENGLISH_H5">
-            <persName>Lords, Attendants, Soldiers, French Prisoners, Messengers</persName>
-          </person>
+          <personGrp xml:id="ATTENDANTS.ENGLISH_H5" sex="UNKNOWN">
+            <name>Lords, Attendants, Soldiers, French Prisoners, Messengers</name>
+          </personGrp>
         </listPerson>
       </particDesc>
     </profileDesc>

--- a/tei/henry-vi-part-1.xml
+++ b/tei/henry-vi-part-1.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,201 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Bedford_H5"><persName>Bedford</persName></person><person xml:id="Gloucester_2H4"><persName>Gloucester</persName></person><person xml:id="Exeter_H5"><persName>Exeter</persName></person><person xml:id="CardinalBeaufort_1H6"><persName>Winchester</persName></person><person xml:id="MESSENGERS.ENGLISH.1_1H6"><persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName></person><person xml:id="MESSENGERS.ENGLISH.2_1H6"><persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName></person><person xml:id="MESSENGERS.ENGLISH.3_1H6"><persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName></person><person xml:id="Charles_1H6"><persName>Charles</persName></person><person xml:id="Alanson_1H6"><persName>Alanson</persName></person><person xml:id="Reignier_1H6"><persName>Reignier</persName></person><person xml:id="Bastard_1H6"><persName>Orleance</persName></person><person xml:id="Pucelle_1H6"><persName>Pucelle</persName></person><person xml:id="WARDERS.1_1H6"><persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName></person><person xml:id="SERVANTS.GLOUCESTER.0.1_1H6"><persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName></person><person xml:id="WARDERS.2_1H6"><persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName></person><person xml:id="Woodville_1H6"><persName>Woodville</persName></person><person xml:id="SERVANTS.GLOUCESTER_1H6"><persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName></person><person xml:id="Mayor_1H6"><persName>Mayor</persName></person><person xml:id="OFFICERS.0.1_1H6"><persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName></person><person xml:id="MasterGunner_1H6"><persName>Master Gunner</persName></person><person xml:id="Boy_1H6"><persName>Boy</persName></person><person xml:id="Salisbury_1H6"><persName>Salisbury</persName></person><person xml:id="Talbot_1H6"><persName>Talbot</persName></person><person xml:id="Gargrave_1H6"><persName>Gargrave</persName></person><person xml:id="Glansdale_1H6"><persName>Glansdale</persName></person><person xml:id="MESSENGERS.ENGLISH.X.1_1H6"><persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName></person><person xml:id="SOLDIERS.FRENCH.Sergeant_1H6"><persName>Sergeant</persName></person><person xml:id="WATCHMEN.1_1H6"><persName>Drummer, Soldiers, two Sentinels, Messenger, Soldiers, Governor of Paris, Herald, Scout, Fiends accompanying Pucelle</persName></person><person xml:id="Burgundy_1H6"><persName>Burgundy</persName></person><person xml:id="SOLDIERS.ENGLISH.1_1H6"><persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName></person><person xml:id="MESSENGERS.FRENCH.1_1H6"><persName>Drummer, Soldiers, two Sentinels, Messenger, Soldiers, Governor of Paris, Herald, Scout, Fiends accompanying Pucelle</persName></person><person xml:id="SOLDIERS.ENGLISH.0.1_1H6"><persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName></person><person xml:id="Countess_1H6"><persName>Countess</persName></person><person xml:id="Porter_1H6"><persName>Porter</persName></person><person xml:id="York_1H6"><persName>Plantagenet York</persName><persName>Plantagenet York</persName></person><person xml:id="Suffolk_1H6"><persName>Suffolk</persName></person><person xml:id="Somerset_1H6"><persName>Somerset</persName></person><person xml:id="Warwick_2H4"><persName>Warwick</persName></person><person xml:id="Vernon_1H6"><persName>Vernon</persName></person><person xml:id="Lawyer_1H6"><persName>Lawyer</persName></person><person xml:id="Mortimer_1H4"><persName>Mortimer</persName></person><person xml:id="JAILERS.0.1_1H6"><persName>The English</persName></person><person xml:id="HenryVI_1H6"><persName>King Henry VI</persName></person><person xml:id="SERVANTS.WINCHESTER.0.1_1H6"><persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName></person><person xml:id="SERVANTS.GLOUCESTER.0.2_1H6"><persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName></person><person xml:id="SERVANTS.1_1H6"><persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName></person><person xml:id="SERVANTS.2_1H6"><persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName></person><person xml:id="SERVANTS.3_1H6"><persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName></person><person xml:id="SOLDIERS.FRENCH.PUCELLE.0.1_1H6"><persName>Drummer, Soldiers, two Sentinels, Messenger, Soldiers, Governor of Paris, Herald, Scout, Fiends accompanying Pucelle</persName></person><person xml:id="Watchman_1H6"><persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName></person><person xml:id="SOLDIERS.ENGLISH.Captain_1H6"><persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName></person><person xml:id="Fastolf_1H6"><persName>Fastolf</persName></person><person xml:id="Basset_1H6"><persName>Basset</persName></person><person xml:id="General_1H6"><persName>General</persName></person><person xml:id="MESSENGERS.ENGLISH.X.2_1H6"><persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName></person><person xml:id="Lucy_1H6"><persName>Lucy</persName></person><person xml:id="SOLDIERS.ENGLISH.SOMERSET.0.1_1H6"><persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName></person><person xml:id="JohnTalbot_1H6"><persName>John Talbot</persName></person><person xml:id="SERVANTS.TALBOT.1_1H6"><persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName></person><person xml:id="Legate_1H6"><persName>Legate</persName></person><person xml:id="SOLDIERS.FRENCH.Scout_1H6"><persName>Drummer, Soldiers, two Sentinels, Messenger, Soldiers, Governor of Paris, Herald, Scout, Fiends accompanying Pucelle</persName></person><person xml:id="QueenMargaret_1H6"><persName>Margaret</persName></person><person xml:id="Shepherd_1H6"><persName>Shepherd</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Bedford_H5">
+            <persName>Bedford</persName>
+          </person>
+          <person xml:id="Gloucester_2H4">
+            <persName>Gloucester</persName>
+          </person>
+          <person xml:id="Exeter_H5">
+            <persName>Exeter</persName>
+          </person>
+          <person xml:id="CardinalBeaufort_1H6">
+            <persName>Winchester</persName>
+          </person>
+          <person xml:id="MESSENGERS.ENGLISH.1_1H6">
+            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
+          </person>
+          <person xml:id="MESSENGERS.ENGLISH.2_1H6">
+            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
+          </person>
+          <person xml:id="MESSENGERS.ENGLISH.3_1H6">
+            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
+          </person>
+          <person xml:id="Charles_1H6">
+            <persName>Charles</persName>
+          </person>
+          <person xml:id="Alanson_1H6">
+            <persName>Alanson</persName>
+          </person>
+          <person xml:id="Reignier_1H6">
+            <persName>Reignier</persName>
+          </person>
+          <person xml:id="Bastard_1H6">
+            <persName>Orleance</persName>
+          </person>
+          <person xml:id="Pucelle_1H6">
+            <persName>Pucelle</persName>
+          </person>
+          <person xml:id="WARDERS.1_1H6">
+            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
+          </person>
+          <person xml:id="SERVANTS.GLOUCESTER.0.1_1H6">
+            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
+          </person>
+          <person xml:id="WARDERS.2_1H6">
+            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
+          </person>
+          <person xml:id="Woodville_1H6">
+            <persName>Woodville</persName>
+          </person>
+          <person xml:id="SERVANTS.GLOUCESTER_1H6">
+            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
+          </person>
+          <person xml:id="Mayor_1H6">
+            <persName>Mayor</persName>
+          </person>
+          <person xml:id="OFFICERS.0.1_1H6">
+            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
+          </person>
+          <person xml:id="MasterGunner_1H6">
+            <persName>Master Gunner</persName>
+          </person>
+          <person xml:id="Boy_1H6">
+            <persName>Boy</persName>
+          </person>
+          <person xml:id="Salisbury_1H6">
+            <persName>Salisbury</persName>
+          </person>
+          <person xml:id="Talbot_1H6">
+            <persName>Talbot</persName>
+          </person>
+          <person xml:id="Gargrave_1H6">
+            <persName>Gargrave</persName>
+          </person>
+          <person xml:id="Glansdale_1H6">
+            <persName>Glansdale</persName>
+          </person>
+          <person xml:id="MESSENGERS.ENGLISH.X.1_1H6">
+            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
+          </person>
+          <person xml:id="SOLDIERS.FRENCH.Sergeant_1H6">
+            <persName>Sergeant</persName>
+          </person>
+          <person xml:id="WATCHMEN.1_1H6">
+            <persName>Drummer, Soldiers, two Sentinels, Messenger, Soldiers, Governor of Paris, Herald, Scout, Fiends accompanying Pucelle</persName>
+          </person>
+          <person xml:id="Burgundy_1H6">
+            <persName>Burgundy</persName>
+          </person>
+          <person xml:id="SOLDIERS.ENGLISH.1_1H6">
+            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
+          </person>
+          <person xml:id="MESSENGERS.FRENCH.1_1H6">
+            <persName>Drummer, Soldiers, two Sentinels, Messenger, Soldiers, Governor of Paris, Herald, Scout, Fiends accompanying Pucelle</persName>
+          </person>
+          <person xml:id="SOLDIERS.ENGLISH.0.1_1H6">
+            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
+          </person>
+          <person xml:id="Countess_1H6">
+            <persName>Countess</persName>
+          </person>
+          <person xml:id="Porter_1H6">
+            <persName>Porter</persName>
+          </person>
+          <person xml:id="York_1H6">
+            <persName>Plantagenet York</persName>
+            <persName>Plantagenet York</persName>
+          </person>
+          <person xml:id="Suffolk_1H6">
+            <persName>Suffolk</persName>
+          </person>
+          <person xml:id="Somerset_1H6">
+            <persName>Somerset</persName>
+          </person>
+          <person xml:id="Warwick_2H4">
+            <persName>Warwick</persName>
+          </person>
+          <person xml:id="Vernon_1H6">
+            <persName>Vernon</persName>
+          </person>
+          <person xml:id="Lawyer_1H6">
+            <persName>Lawyer</persName>
+          </person>
+          <person xml:id="Mortimer_1H4">
+            <persName>Mortimer</persName>
+          </person>
+          <person xml:id="JAILERS.0.1_1H6">
+            <persName>The English</persName>
+          </person>
+          <person xml:id="HenryVI_1H6">
+            <persName>King Henry VI</persName>
+          </person>
+          <person xml:id="SERVANTS.WINCHESTER.0.1_1H6">
+            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
+          </person>
+          <person xml:id="SERVANTS.GLOUCESTER.0.2_1H6">
+            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
+          </person>
+          <person xml:id="SERVANTS.1_1H6">
+            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
+          </person>
+          <person xml:id="SERVANTS.2_1H6">
+            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
+          </person>
+          <person xml:id="SERVANTS.3_1H6">
+            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
+          </person>
+          <person xml:id="SOLDIERS.FRENCH.PUCELLE.0.1_1H6">
+            <persName>Drummer, Soldiers, two Sentinels, Messenger, Soldiers, Governor of Paris, Herald, Scout, Fiends accompanying Pucelle</persName>
+          </person>
+          <person xml:id="Watchman_1H6">
+            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
+          </person>
+          <person xml:id="SOLDIERS.ENGLISH.Captain_1H6">
+            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
+          </person>
+          <person xml:id="Fastolf_1H6">
+            <persName>Fastolf</persName>
+          </person>
+          <person xml:id="Basset_1H6">
+            <persName>Basset</persName>
+          </person>
+          <person xml:id="General_1H6">
+            <persName>General</persName>
+          </person>
+          <person xml:id="MESSENGERS.ENGLISH.X.2_1H6">
+            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
+          </person>
+          <person xml:id="Lucy_1H6">
+            <persName>Lucy</persName>
+          </person>
+          <person xml:id="SOLDIERS.ENGLISH.SOMERSET.0.1_1H6">
+            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
+          </person>
+          <person xml:id="JohnTalbot_1H6">
+            <persName>John Talbot</persName>
+          </person>
+          <person xml:id="SERVANTS.TALBOT.1_1H6">
+            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
+          </person>
+          <person xml:id="Legate_1H6">
+            <persName>Legate</persName>
+          </person>
+          <person xml:id="SOLDIERS.FRENCH.Scout_1H6">
+            <persName>Drummer, Soldiers, two Sentinels, Messenger, Soldiers, Governor of Paris, Herald, Scout, Fiends accompanying Pucelle</persName>
+          </person>
+          <person xml:id="QueenMargaret_1H6">
+            <persName>Margaret</persName>
+          </person>
+          <person xml:id="Shepherd_1H6">
+            <persName>Shepherd</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/henry-vi-part-1.xml
+++ b/tei/henry-vi-part-1.xml
@@ -88,194 +88,194 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Bedford_H5">
+          <person xml:id="Bedford_H5" ana="http://www.wikidata.org/entity/Q348441">
             <persName>Bedford</persName>
           </person>
-          <person xml:id="Gloucester_2H4">
+          <person xml:id="Gloucester_2H4" ana="http://www.wikidata.org/entity/Q447541">
             <persName>Gloucester</persName>
           </person>
-          <person xml:id="Exeter_H5">
+          <person xml:id="Exeter_H5" ana="http://www.wikidata.org/entity/Q660630">
             <persName>Exeter</persName>
           </person>
-          <person xml:id="CardinalBeaufort_1H6">
+          <person xml:id="CardinalBeaufort_1H6" ana="http://www.wikidata.org/entity/Q982472">
             <persName>Winchester</persName>
           </person>
-          <person xml:id="MESSENGERS.ENGLISH.1_1H6">
-            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
-          </person>
-          <person xml:id="MESSENGERS.ENGLISH.2_1H6">
-            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
-          </person>
-          <person xml:id="MESSENGERS.ENGLISH.3_1H6">
-            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
-          </person>
-          <person xml:id="Charles_1H6">
+          <personGrp xml:id="MESSENGERS.ENGLISH.1_1H6" sex="UNKNOWN">
+            <name>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</name>
+          </personGrp>
+          <personGrp xml:id="MESSENGERS.ENGLISH.2_1H6" sex="UNKNOWN">
+            <name>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</name>
+          </personGrp>
+          <personGrp xml:id="MESSENGERS.ENGLISH.3_1H6" sex="UNKNOWN">
+            <name>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</name>
+          </personGrp>
+          <person xml:id="Charles_1H6" ana="http://www.wikidata.org/entity/Q133372">
             <persName>Charles</persName>
           </person>
-          <person xml:id="Alanson_1H6">
+          <person xml:id="Alanson_1H6" ana="http://www.wikidata.org/entity/Q719814">
             <persName>Alanson</persName>
           </person>
-          <person xml:id="Reignier_1H6">
+          <person xml:id="Reignier_1H6" ana="http://www.wikidata.org/entity/Q170353">
             <persName>Reignier</persName>
           </person>
-          <person xml:id="Bastard_1H6">
+          <person xml:id="Bastard_1H6" ana="http://www.wikidata.org/entity/Q503809">
             <persName>Orleance</persName>
           </person>
-          <person xml:id="Pucelle_1H6">
+          <person xml:id="Pucelle_1H6" ana="http://www.wikidata.org/entity/Q7226">
             <persName>Pucelle</persName>
           </person>
-          <person xml:id="WARDERS.1_1H6">
-            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
-          </person>
-          <person xml:id="SERVANTS.GLOUCESTER.0.1_1H6">
-            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
-          </person>
-          <person xml:id="WARDERS.2_1H6">
-            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
-          </person>
-          <person xml:id="Woodville_1H6">
+          <personGrp xml:id="WARDERS.1_1H6" sex="UNKNOWN">
+            <name>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</name>
+          </personGrp>
+          <personGrp xml:id="SERVANTS.GLOUCESTER.0.1_1H6" sex="UNKNOWN">
+            <name>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</name>
+          </personGrp>
+          <personGrp xml:id="WARDERS.2_1H6" sex="UNKNOWN">
+            <name>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</name>
+          </personGrp>
+          <person xml:id="Woodville_1H6" sex="MALE">
             <persName>Woodville</persName>
           </person>
-          <person xml:id="SERVANTS.GLOUCESTER_1H6">
-            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
-          </person>
-          <person xml:id="Mayor_1H6">
+          <personGrp xml:id="SERVANTS.GLOUCESTER_1H6" sex="UNKNOWN">
+            <name>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</name>
+          </personGrp>
+          <person xml:id="Mayor_1H6" sex="MALE">
             <persName>Mayor</persName>
           </person>
-          <person xml:id="OFFICERS.0.1_1H6">
-            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
-          </person>
-          <person xml:id="MasterGunner_1H6">
+          <personGrp xml:id="OFFICERS.0.1_1H6" sex="UNKNOWN">
+            <name>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</name>
+          </personGrp>
+          <person xml:id="MasterGunner_1H6" sex="MALE">
             <persName>Master Gunner</persName>
           </person>
-          <person xml:id="Boy_1H6">
+          <person xml:id="Boy_1H6" sex="MALE">
             <persName>Boy</persName>
           </person>
-          <person xml:id="Salisbury_1H6">
+          <person xml:id="Salisbury_1H6" ana="http://www.wikidata.org/entity/Q1000874">
             <persName>Salisbury</persName>
           </person>
-          <person xml:id="Talbot_1H6">
+          <person xml:id="Talbot_1H6" ana="http://www.wikidata.org/entity/Q561173">
             <persName>Talbot</persName>
           </person>
-          <person xml:id="Gargrave_1H6">
+          <person xml:id="Gargrave_1H6" ana="http://www.wikidata.org/entity/Q16198824">
             <persName>Gargrave</persName>
           </person>
-          <person xml:id="Glansdale_1H6">
+          <person xml:id="Glansdale_1H6" sex="MALE">
             <persName>Glansdale</persName>
           </person>
-          <person xml:id="MESSENGERS.ENGLISH.X.1_1H6">
-            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
-          </person>
-          <person xml:id="SOLDIERS.FRENCH.Sergeant_1H6">
+          <personGrp xml:id="MESSENGERS.ENGLISH.X.1_1H6" sex="UNKNOWN">
+            <name>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</name>
+          </personGrp>
+          <person xml:id="SOLDIERS.FRENCH.Sergeant_1H6" sex="MALE">
             <persName>Sergeant</persName>
           </person>
-          <person xml:id="WATCHMEN.1_1H6">
-            <persName>Drummer, Soldiers, two Sentinels, Messenger, Soldiers, Governor of Paris, Herald, Scout, Fiends accompanying Pucelle</persName>
-          </person>
-          <person xml:id="Burgundy_1H6">
+          <personGrp xml:id="WATCHMEN.1_1H6" sex="UNKNOWN">
+            <name>Drummer, Soldiers, two Sentinels, Messenger, Soldiers, Governor of Paris, Herald, Scout, Fiends accompanying Pucelle</name>
+          </personGrp>
+          <person xml:id="Burgundy_1H6" ana="http://www.wikidata.org/entity/Q239337">
             <persName>Burgundy</persName>
           </person>
-          <person xml:id="SOLDIERS.ENGLISH.1_1H6">
-            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
-          </person>
-          <person xml:id="MESSENGERS.FRENCH.1_1H6">
-            <persName>Drummer, Soldiers, two Sentinels, Messenger, Soldiers, Governor of Paris, Herald, Scout, Fiends accompanying Pucelle</persName>
-          </person>
-          <person xml:id="SOLDIERS.ENGLISH.0.1_1H6">
-            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
-          </person>
-          <person xml:id="Countess_1H6">
+          <personGrp xml:id="SOLDIERS.ENGLISH.1_1H6" sex="UNKNOWN">
+            <name>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</name>
+          </personGrp>
+          <personGrp xml:id="MESSENGERS.FRENCH.1_1H6" sex="UNKNOWN">
+            <name>Drummer, Soldiers, two Sentinels, Messenger, Soldiers, Governor of Paris, Herald, Scout, Fiends accompanying Pucelle</name>
+          </personGrp>
+          <personGrp xml:id="SOLDIERS.ENGLISH.0.1_1H6" sex="UNKNOWN">
+            <name>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</name>
+          </personGrp>
+          <person xml:id="Countess_1H6" sex="FEMALE">
             <persName>Countess</persName>
           </person>
-          <person xml:id="Porter_1H6">
+          <person xml:id="Porter_1H6" sex="MALE">
             <persName>Porter</persName>
           </person>
-          <person xml:id="York_1H6">
+          <person xml:id="York_1H6" ana="http://www.wikidata.org/entity/Q312137">
             <persName>Plantagenet York</persName>
             <persName>Plantagenet York</persName>
           </person>
-          <person xml:id="Suffolk_1H6">
+          <person xml:id="Suffolk_1H6" ana="http://www.wikidata.org/entity/Q584430">
             <persName>Suffolk</persName>
           </person>
-          <person xml:id="Somerset_1H6">
+          <person xml:id="Somerset_1H6" sex="MALE">
             <persName>Somerset</persName>
           </person>
-          <person xml:id="Warwick_2H4">
+          <person xml:id="Warwick_2H4" ana="http://www.wikidata.org/entity/Q592988">
             <persName>Warwick</persName>
           </person>
-          <person xml:id="Vernon_1H6">
+          <person xml:id="Vernon_1H6" sex="MALE">
             <persName>Vernon</persName>
           </person>
-          <person xml:id="Lawyer_1H6">
+          <person xml:id="Lawyer_1H6" sex="MALE">
             <persName>Lawyer</persName>
           </person>
-          <person xml:id="Mortimer_1H4">
+          <person xml:id="Mortimer_1H4" sex="MALE">
             <persName>Mortimer</persName>
           </person>
-          <person xml:id="JAILERS.0.1_1H6">
-            <persName>The English</persName>
-          </person>
-          <person xml:id="HenryVI_1H6">
+          <personGrp xml:id="JAILERS.0.1_1H6" sex="UNKNOWN">
+            <name>The English</name>
+          </personGrp>
+          <person xml:id="HenryVI_1H6" ana="http://www.wikidata.org/entity/Q160337">
             <persName>King Henry VI</persName>
           </person>
-          <person xml:id="SERVANTS.WINCHESTER.0.1_1H6">
-            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
-          </person>
-          <person xml:id="SERVANTS.GLOUCESTER.0.2_1H6">
-            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
-          </person>
-          <person xml:id="SERVANTS.1_1H6">
-            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
-          </person>
-          <person xml:id="SERVANTS.2_1H6">
-            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
-          </person>
-          <person xml:id="SERVANTS.3_1H6">
-            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
-          </person>
-          <person xml:id="SOLDIERS.FRENCH.PUCELLE.0.1_1H6">
-            <persName>Drummer, Soldiers, two Sentinels, Messenger, Soldiers, Governor of Paris, Herald, Scout, Fiends accompanying Pucelle</persName>
-          </person>
-          <person xml:id="Watchman_1H6">
-            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
-          </person>
-          <person xml:id="SOLDIERS.ENGLISH.Captain_1H6">
-            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
-          </person>
-          <person xml:id="Fastolf_1H6">
+          <personGrp xml:id="SERVANTS.WINCHESTER.0.1_1H6" sex="UNKNOWN">
+            <name>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</name>
+          </personGrp>
+          <personGrp xml:id="SERVANTS.GLOUCESTER.0.2_1H6" sex="UNKNOWN">
+            <name>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</name>
+          </personGrp>
+          <personGrp xml:id="SERVANTS.1_1H6" sex="UNKNOWN">
+            <name>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</name>
+          </personGrp>
+          <personGrp xml:id="SERVANTS.2_1H6" sex="UNKNOWN">
+            <name>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</name>
+          </personGrp>
+          <personGrp xml:id="SERVANTS.3_1H6" sex="UNKNOWN">
+            <name>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</name>
+          </personGrp>
+          <personGrp xml:id="SOLDIERS.FRENCH.PUCELLE.0.1_1H6" sex="UNKNOWN">
+            <name>Drummer, Soldiers, two Sentinels, Messenger, Soldiers, Governor of Paris, Herald, Scout, Fiends accompanying Pucelle</name>
+          </personGrp>
+          <personGrp xml:id="Watchman_1H6" sex="UNKNOWN">
+            <name>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</name>
+          </personGrp>
+          <personGrp xml:id="SOLDIERS.ENGLISH.Captain_1H6" sex="UNKNOWN">
+            <name>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</name>
+          </personGrp>
+          <person xml:id="Fastolf_1H6" ana="http://www.wikidata.org/entity/Q71125">
             <persName>Fastolf</persName>
           </person>
-          <person xml:id="Basset_1H6">
+          <person xml:id="Basset_1H6" sex="MALE">
             <persName>Basset</persName>
           </person>
-          <person xml:id="General_1H6">
+          <person xml:id="General_1H6" sex="MALE">
             <persName>General</persName>
           </person>
-          <person xml:id="MESSENGERS.ENGLISH.X.2_1H6">
-            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
-          </person>
-          <person xml:id="Lucy_1H6">
+          <personGrp xml:id="MESSENGERS.ENGLISH.X.2_1H6" sex="UNKNOWN">
+            <name>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</name>
+          </personGrp>
+          <person xml:id="Lucy_1H6" sex="MALE">
             <persName>Lucy</persName>
           </person>
-          <person xml:id="SOLDIERS.ENGLISH.SOMERSET.0.1_1H6">
-            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
-          </person>
-          <person xml:id="JohnTalbot_1H6">
+          <personGrp xml:id="SOLDIERS.ENGLISH.SOMERSET.0.1_1H6" sex="UNKNOWN">
+            <name>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</name>
+          </personGrp>
+          <person xml:id="JohnTalbot_1H6" ana="http://www.wikidata.org/entity/Q6260178">
             <persName>John Talbot</persName>
           </person>
-          <person xml:id="SERVANTS.TALBOT.1_1H6">
-            <persName>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</persName>
-          </person>
-          <person xml:id="Legate_1H6">
+          <personGrp xml:id="SERVANTS.TALBOT.1_1H6" sex="UNKNOWN">
+            <name>Heralds, Attendants, three Messengers, Servingmen in blue coats and in tawny coats, two Warders, Officers, Soldiers, Captains, Watch, Trumpeters, Drummer, Servant, two Ambassadors</name>
+          </personGrp>
+          <person xml:id="Legate_1H6" sex="MALE">
             <persName>Legate</persName>
           </person>
-          <person xml:id="SOLDIERS.FRENCH.Scout_1H6">
-            <persName>Drummer, Soldiers, two Sentinels, Messenger, Soldiers, Governor of Paris, Herald, Scout, Fiends accompanying Pucelle</persName>
-          </person>
-          <person xml:id="QueenMargaret_1H6">
+          <personGrp xml:id="SOLDIERS.FRENCH.Scout_1H6" sex="UNKNOWN">
+            <name>Drummer, Soldiers, two Sentinels, Messenger, Soldiers, Governor of Paris, Herald, Scout, Fiends accompanying Pucelle</name>
+          </personGrp>
+          <person xml:id="QueenMargaret_1H6" ana="http://www.wikidata.org/entity/Q231145">
             <persName>Margaret</persName>
           </person>
-          <person xml:id="Shepherd_1H6">
+          <person xml:id="Shepherd_1H6" ana="http://www.wikidata.org/entity/Q3160219">
             <persName>Shepherd</persName>
           </person>
         </listPerson>

--- a/tei/henry-vi-part-2.xml
+++ b/tei/henry-vi-part-2.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts encodes the edition of each play by Barbara Mowat and Paul Werstine in TEI Simple. The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,227 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Suffolk_1H6"><persName>Suffolk</persName></person><person xml:id="HenryVI_1H6"><persName>King Henry VI</persName></person><person xml:id="QueenMargaret_1H6"><persName>Queen Margaret</persName></person><person xml:id="Gloucester_2H4"><persName>Gloucester</persName></person><person xml:id="CardinalBeaufort_1H6"><persName>Cardinal</persName></person><person xml:id="Somerset_1H6"><persName>Somerset</persName></person><person xml:id="Buckingham_2H6"><persName>Buckingham</persName></person><person xml:id="York_1H6"><persName>York</persName></person><person xml:id="Salisbury_2H6"><persName>Salisbury</persName></person><person xml:id="Warwick_2H6"><persName>Warwick</persName></person><person xml:id="DuchessOfGloucester_2H6"><persName>Duchess</persName></person><person xml:id="MESSENGERS.X.1_2H6"><persName>MESSENGERS.X.1_2H6</persName></person><person xml:id="Hume_2H6"><persName>Hume</persName></person><person xml:id="PETITIONERS.0.1_2H6"><persName>PETITIONERS.0.1_2H6</persName></person><person xml:id="PETITIONERS.0.2_2H6"><persName>PETITIONERS.0.2_2H6</persName></person><person xml:id="Thump_2H6"><persName>Thump</persName></person><person xml:id="PETITIONERS_2H6"><persName>Petitioners</persName></person><person xml:id="Horner_2H6"><persName>Horner</persName></person><person xml:id="Bolingbroke_2H6"><persName>Bolingbroke</persName></person><person xml:id="Spirit_2H6"><persName>Spirit</persName></person><person xml:id="Jourdain_2H6"><persName>Jourdain</persName></person><person xml:id="CITIZENS.STALBANS.0.1_2H6"><persName>Man</persName></person><person xml:id="Simpcox_2H6"><persName>Simpcox</persName></person><person xml:id="SimpcoxWife_2H6"><persName>Wife</persName></person><person xml:id="MayorOfStAlbans_2H6"><persName>Mayor</persName></person><person xml:id="Beadle_2H6"><persName>Beadle</persName></person><person xml:id="NEIGHBORS.1_2H6"><persName>NEIGHBORS.1_2H6</persName></person><person xml:id="NEIGHBORS.2_2H6"><persName>NEIGHBORS.2_2H6</persName></person><person xml:id="NEIGHBORS.3_2H6"><persName>NEIGHBORS.3_2H6</persName></person><person xml:id="PRENTICES.1_2H6"><persName>PRENTICES.1_2H6</persName></person><person xml:id="PRENTICES.2_2H6"><persName>PRENTICES.2_2H6</persName></person><person xml:id="SERVANTS.GLOUCESTER.0.1_2H6"><persName>SERVANTS.GLOUCESTER.0.1_2H6</persName></person><person xml:id="HERALDS.X.1_2H6"><persName>HERALDS.X.1_2H6</persName></person><person xml:id="Sheriff_2H6"><persName>Sheriff</persName></person><person xml:id="Stanley_2H6"><persName>Stanley</persName></person><person xml:id="MESSENGERS.Post_2H6"><persName>Post</persName></person><person xml:id="MURDERERS.0.1_2H6"><persName>MURDERERS.0.1_2H6</persName></person><person xml:id="MURDERERS.0.2_2H6"><persName>MURDERERS.0.2_2H6</persName></person><person xml:id="CITIZENS_2H6"><persName>CITIZENS_2H6</persName></person><person xml:id="Vaux_2H6"><persName>Vaux</persName></person><person xml:id="Lieutenant_2H6"><persName>Lieutenant</persName></person><person xml:id="GENTLEMEN.1_2H6"><persName>GENTLEMEN.1_2H6</persName></person><person xml:id="Master_2H6"><persName>Master</persName></person><person xml:id="Mate_2H6"><persName>Mate</persName></person><person xml:id="GENTLEMEN.2_2H6"><persName>GENTLEMEN.2_2H6</persName></person><person xml:id="Whitmore_2H6"><persName>Whitmore</persName></person><person xml:id="Bevis_2H6"><persName>Bevis</persName></person><person xml:id="Holland_2H6"><persName>Holland</persName></person><person xml:id="Cade_2H6"><persName>Cade</persName></person><person xml:id="Dick_2H6"><persName>Dick</persName></person><person xml:id="Smith_2H6"><persName>Smith</persName></person><person xml:id="Sawyer_2H6"><persName>Servants, Guards, Falconers, Attendants, Townsmen of Saint Albans, Bearers, Drummers, Commoners, Rebels, a Sawyer, Soldiers, Officers, Matthew Gough, and Others</persName></person><person xml:id="FOLLOWERS.CADE_2H6"><persName>Servants, Guards, Falconers, Attendants, Townsmen of Saint Albans, Bearers, Drummers, Commoners, Rebels, a Sawyer, Soldiers, Officers, Matthew Gough, and Others</persName></person><person xml:id="Clerk_2H6"><persName>Clerk</persName></person><person xml:id="Michael_2H6"><persName>Michael</persName></person><person xml:id="Stafford_2H6"><persName>Stafford</persName></person><person xml:id="WilliamStafford_2H6"><persName>Brother</persName></person><person xml:id="Saye_2H6"><persName>Saye</persName></person><person xml:id="MESSENGERS.1_2H6"><persName>MESSENGERS.1_2H6</persName></person><person xml:id="MESSENGERS.2_2H6"><persName>MESSENGERS.2_2H6</persName></person><person xml:id="Scales_2H6"><persName>Scales</persName></person><person xml:id="CITIZENS.LONDON.0.1_2H6"><persName>CITIZENS.LONDON.0.1_2H6</persName></person><person xml:id="SOLDIERS.1_2H6"><persName>Servants, Guards, Falconers, Attendants, Townsmen of Saint Albans, Bearers, Drummers, Commoners, Rebels, a Sawyer, Soldiers, Officers, Matthew Gough, and Others</persName></person><person xml:id="MESSENGERS.X.2_2H6"><persName>MESSENGERS.X.2_2H6</persName></person><person xml:id="George_2H6"><persName>George</persName></person><person xml:id="FOLLOWERS.CADE.0_2H6"><persName>Servants, Guards, Falconers, Attendants, Townsmen of Saint Albans, Bearers, Drummers, Commoners, Rebels, a Sawyer, Soldiers, Officers, Matthew Gough, and Others</persName></person><person xml:id="Clifford_2H6"><persName>Clifford</persName></person><person xml:id="MESSENGERS.X.3_2H6"><persName>MESSENGERS.X.3_2H6</persName></person><person xml:id="Iden_2H6"><persName>Iden</persName></person><person xml:id="EdwardIV_3H6"><persName>Edward</persName></person><person xml:id="RichardIII_R3"><persName>Richard</persName></person><person xml:id="Clifford_3H6"><persName>Young Clifford</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Suffolk_1H6">
+            <persName>Suffolk</persName>
+          </person>
+          <person xml:id="HenryVI_1H6">
+            <persName>King Henry VI</persName>
+          </person>
+          <person xml:id="QueenMargaret_1H6">
+            <persName>Queen Margaret</persName>
+          </person>
+          <person xml:id="Gloucester_2H4">
+            <persName>Gloucester</persName>
+          </person>
+          <person xml:id="CardinalBeaufort_1H6">
+            <persName>Cardinal</persName>
+          </person>
+          <person xml:id="Somerset_1H6">
+            <persName>Somerset</persName>
+          </person>
+          <person xml:id="Buckingham_2H6">
+            <persName>Buckingham</persName>
+          </person>
+          <person xml:id="York_1H6">
+            <persName>York</persName>
+          </person>
+          <person xml:id="Salisbury_2H6">
+            <persName>Salisbury</persName>
+          </person>
+          <person xml:id="Warwick_2H6">
+            <persName>Warwick</persName>
+          </person>
+          <person xml:id="DuchessOfGloucester_2H6">
+            <persName>Duchess</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.1_2H6">
+            <persName>MESSENGERS.X.1_2H6</persName>
+          </person>
+          <person xml:id="Hume_2H6">
+            <persName>Hume</persName>
+          </person>
+          <person xml:id="PETITIONERS.0.1_2H6">
+            <persName>PETITIONERS.0.1_2H6</persName>
+          </person>
+          <person xml:id="PETITIONERS.0.2_2H6">
+            <persName>PETITIONERS.0.2_2H6</persName>
+          </person>
+          <person xml:id="Thump_2H6">
+            <persName>Thump</persName>
+          </person>
+          <person xml:id="PETITIONERS_2H6">
+            <persName>Petitioners</persName>
+          </person>
+          <person xml:id="Horner_2H6">
+            <persName>Horner</persName>
+          </person>
+          <person xml:id="Bolingbroke_2H6">
+            <persName>Bolingbroke</persName>
+          </person>
+          <person xml:id="Spirit_2H6">
+            <persName>Spirit</persName>
+          </person>
+          <person xml:id="Jourdain_2H6">
+            <persName>Jourdain</persName>
+          </person>
+          <person xml:id="CITIZENS.STALBANS.0.1_2H6">
+            <persName>Man</persName>
+          </person>
+          <person xml:id="Simpcox_2H6">
+            <persName>Simpcox</persName>
+          </person>
+          <person xml:id="SimpcoxWife_2H6">
+            <persName>Wife</persName>
+          </person>
+          <person xml:id="MayorOfStAlbans_2H6">
+            <persName>Mayor</persName>
+          </person>
+          <person xml:id="Beadle_2H6">
+            <persName>Beadle</persName>
+          </person>
+          <person xml:id="NEIGHBORS.1_2H6">
+            <persName>NEIGHBORS.1_2H6</persName>
+          </person>
+          <person xml:id="NEIGHBORS.2_2H6">
+            <persName>NEIGHBORS.2_2H6</persName>
+          </person>
+          <person xml:id="NEIGHBORS.3_2H6">
+            <persName>NEIGHBORS.3_2H6</persName>
+          </person>
+          <person xml:id="PRENTICES.1_2H6">
+            <persName>PRENTICES.1_2H6</persName>
+          </person>
+          <person xml:id="PRENTICES.2_2H6">
+            <persName>PRENTICES.2_2H6</persName>
+          </person>
+          <person xml:id="SERVANTS.GLOUCESTER.0.1_2H6">
+            <persName>SERVANTS.GLOUCESTER.0.1_2H6</persName>
+          </person>
+          <person xml:id="HERALDS.X.1_2H6">
+            <persName>HERALDS.X.1_2H6</persName>
+          </person>
+          <person xml:id="Sheriff_2H6">
+            <persName>Sheriff</persName>
+          </person>
+          <person xml:id="Stanley_2H6">
+            <persName>Stanley</persName>
+          </person>
+          <person xml:id="MESSENGERS.Post_2H6">
+            <persName>Post</persName>
+          </person>
+          <person xml:id="MURDERERS.0.1_2H6">
+            <persName>MURDERERS.0.1_2H6</persName>
+          </person>
+          <person xml:id="MURDERERS.0.2_2H6">
+            <persName>MURDERERS.0.2_2H6</persName>
+          </person>
+          <person xml:id="CITIZENS_2H6">
+            <persName>CITIZENS_2H6</persName>
+          </person>
+          <person xml:id="Vaux_2H6">
+            <persName>Vaux</persName>
+          </person>
+          <person xml:id="Lieutenant_2H6">
+            <persName>Lieutenant</persName>
+          </person>
+          <person xml:id="GENTLEMEN.1_2H6">
+            <persName>GENTLEMEN.1_2H6</persName>
+          </person>
+          <person xml:id="Master_2H6">
+            <persName>Master</persName>
+          </person>
+          <person xml:id="Mate_2H6">
+            <persName>Mate</persName>
+          </person>
+          <person xml:id="GENTLEMEN.2_2H6">
+            <persName>GENTLEMEN.2_2H6</persName>
+          </person>
+          <person xml:id="Whitmore_2H6">
+            <persName>Whitmore</persName>
+          </person>
+          <person xml:id="Bevis_2H6">
+            <persName>Bevis</persName>
+          </person>
+          <person xml:id="Holland_2H6">
+            <persName>Holland</persName>
+          </person>
+          <person xml:id="Cade_2H6">
+            <persName>Cade</persName>
+          </person>
+          <person xml:id="Dick_2H6">
+            <persName>Dick</persName>
+          </person>
+          <person xml:id="Smith_2H6">
+            <persName>Smith</persName>
+          </person>
+          <person xml:id="Sawyer_2H6">
+            <persName>Servants, Guards, Falconers, Attendants, Townsmen of Saint Albans, Bearers, Drummers, Commoners, Rebels, a Sawyer, Soldiers, Officers, Matthew Gough, and Others</persName>
+          </person>
+          <person xml:id="FOLLOWERS.CADE_2H6">
+            <persName>Servants, Guards, Falconers, Attendants, Townsmen of Saint Albans, Bearers, Drummers, Commoners, Rebels, a Sawyer, Soldiers, Officers, Matthew Gough, and Others</persName>
+          </person>
+          <person xml:id="Clerk_2H6">
+            <persName>Clerk</persName>
+          </person>
+          <person xml:id="Michael_2H6">
+            <persName>Michael</persName>
+          </person>
+          <person xml:id="Stafford_2H6">
+            <persName>Stafford</persName>
+          </person>
+          <person xml:id="WilliamStafford_2H6">
+            <persName>Brother</persName>
+          </person>
+          <person xml:id="Saye_2H6">
+            <persName>Saye</persName>
+          </person>
+          <person xml:id="MESSENGERS.1_2H6">
+            <persName>MESSENGERS.1_2H6</persName>
+          </person>
+          <person xml:id="MESSENGERS.2_2H6">
+            <persName>MESSENGERS.2_2H6</persName>
+          </person>
+          <person xml:id="Scales_2H6">
+            <persName>Scales</persName>
+          </person>
+          <person xml:id="CITIZENS.LONDON.0.1_2H6">
+            <persName>CITIZENS.LONDON.0.1_2H6</persName>
+          </person>
+          <person xml:id="SOLDIERS.1_2H6">
+            <persName>Servants, Guards, Falconers, Attendants, Townsmen of Saint Albans, Bearers, Drummers, Commoners, Rebels, a Sawyer, Soldiers, Officers, Matthew Gough, and Others</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.2_2H6">
+            <persName>MESSENGERS.X.2_2H6</persName>
+          </person>
+          <person xml:id="George_2H6">
+            <persName>George</persName>
+          </person>
+          <person xml:id="FOLLOWERS.CADE.0_2H6">
+            <persName>Servants, Guards, Falconers, Attendants, Townsmen of Saint Albans, Bearers, Drummers, Commoners, Rebels, a Sawyer, Soldiers, Officers, Matthew Gough, and Others</persName>
+          </person>
+          <person xml:id="Clifford_2H6">
+            <persName>Clifford</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.3_2H6">
+            <persName>MESSENGERS.X.3_2H6</persName>
+          </person>
+          <person xml:id="Iden_2H6">
+            <persName>Iden</persName>
+          </person>
+          <person xml:id="EdwardIV_3H6">
+            <persName>Edward</persName>
+          </person>
+          <person xml:id="RichardIII_R3">
+            <persName>Richard</persName>
+          </person>
+          <person xml:id="Clifford_3H6">
+            <persName>Young Clifford</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/henry-vi-part-2.xml
+++ b/tei/henry-vi-part-2.xml
@@ -88,220 +88,220 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Suffolk_1H6">
+          <person xml:id="Suffolk_1H6" ana="http://www.wikidata.org/entity/Q584430">
             <persName>Suffolk</persName>
           </person>
-          <person xml:id="HenryVI_1H6">
+          <person xml:id="HenryVI_1H6" ana="http://www.wikidata.org/entity/Q160337">
             <persName>King Henry VI</persName>
           </person>
-          <person xml:id="QueenMargaret_1H6">
+          <person xml:id="QueenMargaret_1H6" ana="http://www.wikidata.org/entity/Q229159">
             <persName>Queen Margaret</persName>
           </person>
-          <person xml:id="Gloucester_2H4">
+          <person xml:id="Gloucester_2H4" sex="MALE">
             <persName>Gloucester</persName>
           </person>
-          <person xml:id="CardinalBeaufort_1H6">
+          <person xml:id="CardinalBeaufort_1H6" sex="MALE">
             <persName>Cardinal</persName>
           </person>
-          <person xml:id="Somerset_1H6">
+          <person xml:id="Somerset_1H6" ana="http://www.wikidata.org/entity/Q919338">
             <persName>Somerset</persName>
           </person>
-          <person xml:id="Buckingham_2H6">
+          <person xml:id="Buckingham_2H6" sex="MALE">
             <persName>Buckingham</persName>
           </person>
-          <person xml:id="York_1H6">
+          <person xml:id="York_1H6" ana="http://www.wikidata.org/entity/Q312137">
             <persName>York</persName>
           </person>
-          <person xml:id="Salisbury_2H6">
+          <person xml:id="Salisbury_2H6" ana="http://www.wikidata.org/entity/Q384856">
             <persName>Salisbury</persName>
           </person>
-          <person xml:id="Warwick_2H6">
+          <person xml:id="Warwick_2H6" ana="http://www.wikidata.org/entity/Q592988">
             <persName>Warwick</persName>
           </person>
-          <person xml:id="DuchessOfGloucester_2H6">
+          <person xml:id="DuchessOfGloucester_2H6" ana="http://www.wikidata.org/entity/Q25583">
             <persName>Duchess</persName>
           </person>
-          <person xml:id="MESSENGERS.X.1_2H6">
+          <person xml:id="MESSENGERS.X.1_2H6" sex="MALE">
             <persName>MESSENGERS.X.1_2H6</persName>
           </person>
-          <person xml:id="Hume_2H6">
+          <person xml:id="Hume_2H6" sex="MALE">
             <persName>Hume</persName>
           </person>
-          <person xml:id="PETITIONERS.0.1_2H6">
+          <person xml:id="PETITIONERS.0.1_2H6" sex="MALE">
             <persName>PETITIONERS.0.1_2H6</persName>
           </person>
-          <person xml:id="PETITIONERS.0.2_2H6">
+          <person xml:id="PETITIONERS.0.2_2H6" sex="MALE">
             <persName>PETITIONERS.0.2_2H6</persName>
           </person>
-          <person xml:id="Thump_2H6">
+          <person xml:id="Thump_2H6" sex="MALE">
             <persName>Thump</persName>
           </person>
-          <person xml:id="PETITIONERS_2H6">
-            <persName>Petitioners</persName>
-          </person>
-          <person xml:id="Horner_2H6">
+          <personGrp xml:id="PETITIONERS_2H6" sex="UNKNOWN">
+            <name>Petitioners</name>
+          </personGrp>
+          <person xml:id="Horner_2H6" sex="MALE">
             <persName>Horner</persName>
           </person>
-          <person xml:id="Bolingbroke_2H6">
+          <person xml:id="Bolingbroke_2H6" sex="MALE">
             <persName>Bolingbroke</persName>
           </person>
-          <person xml:id="Spirit_2H6">
+          <person xml:id="Spirit_2H6" sex="UNKNOWN">
             <persName>Spirit</persName>
           </person>
-          <person xml:id="Jourdain_2H6">
+          <person xml:id="Jourdain_2H6" sex="FEMALE">
             <persName>Jourdain</persName>
           </person>
-          <person xml:id="CITIZENS.STALBANS.0.1_2H6">
+          <person xml:id="CITIZENS.STALBANS.0.1_2H6" sex="MALE">
             <persName>Man</persName>
           </person>
-          <person xml:id="Simpcox_2H6">
+          <person xml:id="Simpcox_2H6" sex="MALE">
             <persName>Simpcox</persName>
           </person>
-          <person xml:id="SimpcoxWife_2H6">
+          <person xml:id="SimpcoxWife_2H6" sex="FEMALE">
             <persName>Wife</persName>
           </person>
-          <person xml:id="MayorOfStAlbans_2H6">
+          <person xml:id="MayorOfStAlbans_2H6" sex="MALE">
             <persName>Mayor</persName>
           </person>
-          <person xml:id="Beadle_2H6">
+          <person xml:id="Beadle_2H6" sex="MALE">
             <persName>Beadle</persName>
           </person>
-          <person xml:id="NEIGHBORS.1_2H6">
-            <persName>NEIGHBORS.1_2H6</persName>
-          </person>
-          <person xml:id="NEIGHBORS.2_2H6">
-            <persName>NEIGHBORS.2_2H6</persName>
-          </person>
-          <person xml:id="NEIGHBORS.3_2H6">
-            <persName>NEIGHBORS.3_2H6</persName>
-          </person>
-          <person xml:id="PRENTICES.1_2H6">
+          <personGrp xml:id="NEIGHBORS.1_2H6" sex="UNKNOWN">
+            <name>NEIGHBORS.1_2H6</name>
+          </personGrp>
+          <personGrp xml:id="NEIGHBORS.2_2H6" sex="UNKNOWN">
+            <name>NEIGHBORS.2_2H6</name>
+          </personGrp>
+          <personGrp xml:id="NEIGHBORS.3_2H6" sex="UNKNOWN">
+            <name>NEIGHBORS.3_2H6</name>
+          </personGrp>
+          <person xml:id="PRENTICES.1_2H6" sex="MALE">
             <persName>PRENTICES.1_2H6</persName>
           </person>
-          <person xml:id="PRENTICES.2_2H6">
+          <person xml:id="PRENTICES.2_2H6" sex="MALE">
             <persName>PRENTICES.2_2H6</persName>
           </person>
-          <person xml:id="SERVANTS.GLOUCESTER.0.1_2H6">
-            <persName>SERVANTS.GLOUCESTER.0.1_2H6</persName>
-          </person>
-          <person xml:id="HERALDS.X.1_2H6">
+          <personGrp xml:id="SERVANTS.GLOUCESTER.0.1_2H6" sex="UNKNOWN">
+            <name>SERVANTS.GLOUCESTER.0.1_2H6</name>
+          </personGrp>
+          <person xml:id="HERALDS.X.1_2H6" sex="MALE">
             <persName>HERALDS.X.1_2H6</persName>
           </person>
-          <person xml:id="Sheriff_2H6">
+          <person xml:id="Sheriff_2H6" sex="MALE">
             <persName>Sheriff</persName>
           </person>
-          <person xml:id="Stanley_2H6">
+          <person xml:id="Stanley_2H6" ana="http://www.wikidata.org/entity/Q335295">
             <persName>Stanley</persName>
           </person>
-          <person xml:id="MESSENGERS.Post_2H6">
+          <person xml:id="MESSENGERS.Post_2H6" sex="UNKNOWN">
             <persName>Post</persName>
           </person>
-          <person xml:id="MURDERERS.0.1_2H6">
-            <persName>MURDERERS.0.1_2H6</persName>
-          </person>
-          <person xml:id="MURDERERS.0.2_2H6">
-            <persName>MURDERERS.0.2_2H6</persName>
-          </person>
-          <person xml:id="CITIZENS_2H6">
-            <persName>CITIZENS_2H6</persName>
-          </person>
-          <person xml:id="Vaux_2H6">
+          <personGrp xml:id="MURDERERS.0.1_2H6" sex="UNKNOWN">
+            <name>MURDERERS.0.1_2H6</name>
+          </personGrp>
+          <personGrp xml:id="MURDERERS.0.2_2H6" sex="UNKNOWN">
+            <name>MURDERERS.0.2_2H6</name>
+          </personGrp>
+          <personGrp xml:id="CITIZENS_2H6" sex="UNKNOWN">
+            <name>CITIZENS_2H6</name>
+          </personGrp>
+          <person xml:id="Vaux_2H6" sex="MALE">
             <persName>Vaux</persName>
           </person>
-          <person xml:id="Lieutenant_2H6">
+          <person xml:id="Lieutenant_2H6" sex="MALE">
             <persName>Lieutenant</persName>
           </person>
-          <person xml:id="GENTLEMEN.1_2H6">
+          <person xml:id="GENTLEMEN.1_2H6" sex="MALE">
             <persName>GENTLEMEN.1_2H6</persName>
           </person>
-          <person xml:id="Master_2H6">
+          <person xml:id="Master_2H6" sex="MALE">
             <persName>Master</persName>
           </person>
-          <person xml:id="Mate_2H6">
+          <person xml:id="Mate_2H6" sex="MALE">
             <persName>Mate</persName>
           </person>
-          <person xml:id="GENTLEMEN.2_2H6">
+          <person xml:id="GENTLEMEN.2_2H6" sex="MALE">
             <persName>GENTLEMEN.2_2H6</persName>
           </person>
-          <person xml:id="Whitmore_2H6">
+          <person xml:id="Whitmore_2H6" sex="MALE">
             <persName>Whitmore</persName>
           </person>
-          <person xml:id="Bevis_2H6">
+          <person xml:id="Bevis_2H6" sex="MALE">
             <persName>Bevis</persName>
           </person>
-          <person xml:id="Holland_2H6">
+          <person xml:id="Holland_2H6" sex="MALE">
             <persName>Holland</persName>
           </person>
-          <person xml:id="Cade_2H6">
+          <person xml:id="Cade_2H6" ana="http://www.wikidata.org/entity/Q613385">
             <persName>Cade</persName>
           </person>
-          <person xml:id="Dick_2H6">
+          <person xml:id="Dick_2H6" sex="MALE">
             <persName>Dick</persName>
           </person>
-          <person xml:id="Smith_2H6">
+          <person xml:id="Smith_2H6" sex="MALE">
             <persName>Smith</persName>
           </person>
-          <person xml:id="Sawyer_2H6">
-            <persName>Servants, Guards, Falconers, Attendants, Townsmen of Saint Albans, Bearers, Drummers, Commoners, Rebels, a Sawyer, Soldiers, Officers, Matthew Gough, and Others</persName>
-          </person>
-          <person xml:id="FOLLOWERS.CADE_2H6">
-            <persName>Servants, Guards, Falconers, Attendants, Townsmen of Saint Albans, Bearers, Drummers, Commoners, Rebels, a Sawyer, Soldiers, Officers, Matthew Gough, and Others</persName>
-          </person>
-          <person xml:id="Clerk_2H6">
+          <personGrp xml:id="Sawyer_2H6" sex="UNKNOWN">
+            <name>Servants, Guards, Falconers, Attendants, Townsmen of Saint Albans, Bearers, Drummers, Commoners, Rebels, a Sawyer, Soldiers, Officers, Matthew Gough, and Others</name>
+          </personGrp>
+          <personGrp xml:id="FOLLOWERS.CADE_2H6" sex="UNKNOWN">
+            <name>Servants, Guards, Falconers, Attendants, Townsmen of Saint Albans, Bearers, Drummers, Commoners, Rebels, a Sawyer, Soldiers, Officers, Matthew Gough, and Others</name>
+          </personGrp>
+          <person xml:id="Clerk_2H6" sex="MALE">
             <persName>Clerk</persName>
           </person>
-          <person xml:id="Michael_2H6">
+          <person xml:id="Michael_2H6" sex="MALE">
             <persName>Michael</persName>
           </person>
-          <person xml:id="Stafford_2H6">
+          <person xml:id="Stafford_2H6" sex="MALE">
             <persName>Stafford</persName>
           </person>
-          <person xml:id="WilliamStafford_2H6">
+          <person xml:id="WilliamStafford_2H6" sex="MALE">
             <persName>Brother</persName>
           </person>
-          <person xml:id="Saye_2H6">
+          <person xml:id="Saye_2H6" sex="MALE">
             <persName>Saye</persName>
           </person>
-          <person xml:id="MESSENGERS.1_2H6">
+          <person xml:id="MESSENGERS.1_2H6" sex="MALE">
             <persName>MESSENGERS.1_2H6</persName>
           </person>
-          <person xml:id="MESSENGERS.2_2H6">
+          <person xml:id="MESSENGERS.2_2H6" sex="MALE">
             <persName>MESSENGERS.2_2H6</persName>
           </person>
-          <person xml:id="Scales_2H6">
+          <person xml:id="Scales_2H6" sex="MALE">
             <persName>Scales</persName>
           </person>
-          <person xml:id="CITIZENS.LONDON.0.1_2H6">
-            <persName>CITIZENS.LONDON.0.1_2H6</persName>
-          </person>
-          <person xml:id="SOLDIERS.1_2H6">
-            <persName>Servants, Guards, Falconers, Attendants, Townsmen of Saint Albans, Bearers, Drummers, Commoners, Rebels, a Sawyer, Soldiers, Officers, Matthew Gough, and Others</persName>
-          </person>
-          <person xml:id="MESSENGERS.X.2_2H6">
+          <personGrp xml:id="CITIZENS.LONDON.0.1_2H6" sex="UNKNOWN">
+            <name>CITIZENS.LONDON.0.1_2H6</name>
+          </personGrp>
+          <personGrp xml:id="SOLDIERS.1_2H6" sex="UNKNOWN">
+            <name>Servants, Guards, Falconers, Attendants, Townsmen of Saint Albans, Bearers, Drummers, Commoners, Rebels, a Sawyer, Soldiers, Officers, Matthew Gough, and Others</name>
+          </personGrp>
+          <person xml:id="MESSENGERS.X.2_2H6" sex="MALE">
             <persName>MESSENGERS.X.2_2H6</persName>
           </person>
-          <person xml:id="George_2H6">
+          <person xml:id="George_2H6" sex="MALE">
             <persName>George</persName>
           </person>
-          <person xml:id="FOLLOWERS.CADE.0_2H6">
-            <persName>Servants, Guards, Falconers, Attendants, Townsmen of Saint Albans, Bearers, Drummers, Commoners, Rebels, a Sawyer, Soldiers, Officers, Matthew Gough, and Others</persName>
-          </person>
-          <person xml:id="Clifford_2H6">
+          <personGrp xml:id="FOLLOWERS.CADE.0_2H6" sex="UNKNOWN">
+            <name>Servants, Guards, Falconers, Attendants, Townsmen of Saint Albans, Bearers, Drummers, Commoners, Rebels, a Sawyer, Soldiers, Officers, Matthew Gough, and Others</name>
+          </personGrp>
+          <person xml:id="Clifford_2H6" ana="http://www.wikidata.org/entity/Q7788470">
             <persName>Clifford</persName>
           </person>
-          <person xml:id="MESSENGERS.X.3_2H6">
+          <person xml:id="MESSENGERS.X.3_2H6" sex="MALE">
             <persName>MESSENGERS.X.3_2H6</persName>
           </person>
-          <person xml:id="Iden_2H6">
+          <person xml:id="Iden_2H6" sex="MALE">
             <persName>Iden</persName>
           </person>
-          <person xml:id="EdwardIV_3H6">
+          <person xml:id="EdwardIV_3H6" ana="http://www.wikidata.org/entity/Q160341">
             <persName>Edward</persName>
           </person>
-          <person xml:id="RichardIII_R3">
+          <person xml:id="RichardIII_R3" ana="http://www.wikidata.org/entity/Q133028">
             <persName>Richard</persName>
           </person>
-          <person xml:id="Clifford_3H6">
+          <person xml:id="Clifford_3H6" sex="MALE">
             <persName>Young Clifford</persName>
           </person>
         </listPerson>

--- a/tei/henry-vi-part-3.xml
+++ b/tei/henry-vi-part-3.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts encodes the edition of each play by Barbara Mowat and Paul Werstine in TEI Simple. The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptionss and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,162 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Warwick_2H6"><persName>Warwick</persName></person><person xml:id="York_1H6"><persName>York</persName></person><person xml:id="EdwardIV_3H6"><persName>Edward King Edward IV</persName><persName>Edward King Edward IV</persName></person><person xml:id="Montague_3H6"><persName>Montague</persName></person><person xml:id="RichardIII_R3"><persName>Richard Gloucester</persName><persName>Richard Gloucester</persName></person><person xml:id="Norfolk_3H6"><persName>Norfolk</persName></person><person xml:id="HenryVI_1H6"><persName>King Henry VI</persName></person><person xml:id="Northumberland_3H6"><persName>Northumberland</persName></person><person xml:id="Clifford_3H6"><persName>Clifford</persName></person><person xml:id="Westmorland_3H6"><persName>Westmorland</persName></person><person xml:id="Exeter_3H6"><persName>Exeter</persName></person><person xml:id="QueenMargaret_1H6"><persName>Queen Margaret</persName></person><person xml:id="PrinceEdward_3H6"><persName>Prince Edward</persName></person><person xml:id="MESSENGERS.X.1_3H6"><persName>MESSENGERS.X.1_3H6</persName></person><person xml:id="JohnMortimer_3H6"><persName>Sir John</persName></person><person xml:id="Rutland_3H6"><persName>Rutland</persName></person><person xml:id="Tutor_3H6"><persName>Tutor</persName></person><person xml:id="MESSENGERS.X.2_3H6"><persName>MESSENGERS.X.2_3H6</persName></person><person xml:id="MESSENGERS.X.3_3H6"><persName>MESSENGERS.X.3_3H6</persName></person><person xml:id="MESSENGERS.X.4_3H6"><persName>MESSENGERS.X.4_3H6</persName></person><person xml:id="Clarence_3H6"><persName>George Clarence</persName><persName>George Clarence</persName></person><person xml:id="Son_3H6"><persName>Son</persName></person><person xml:id="Father_3H6"><persName>Father</persName></person><person xml:id="GAMEKEEPERS.1_3H6"><persName>First Gamekeeper</persName></person><person xml:id="GAMEKEEPERS.2_3H6"><persName>Second Gamekeeper</persName></person><person xml:id="QueenElizabeth_3H6"><persName>Lady Grey Queen Elizabeth</persName><persName>Lady Grey Queen Elizabeth</persName></person><person xml:id="ATTENDANTS.EDWARD.1_3H6"><persName>Nobleman</persName></person><person xml:id="KingLewis_3H6"><persName>King Lewis</persName></person><person xml:id="Oxford_3H6"><persName>Oxford</persName></person><person xml:id="LadyBona_3H6"><persName>Lady Bona</persName></person><person xml:id="MESSENGERS.Post_3H6"><persName>Post</persName></person><person xml:id="Somerset_3H6"><persName>Somerset</persName></person><person xml:id="Hastings_3H6"><persName>Hastings</persName></person><person xml:id="WATCHMEN.1_3H6"><persName>First Watch</persName></person><person xml:id="WATCHMEN.2_3H6"><persName>Second Watch</persName></person><person xml:id="WATCHMEN.3_3H6"><persName>Third Watch</persName></person><person xml:id="Rivers_3H6"><persName>Rivers</persName></person><person xml:id="Huntsman_3H6"><persName>Huntsman</persName></person><person xml:id="Lieutenant_3H6"><persName>Lieutenant</persName></person><person xml:id="MayorOfYork_3H6"><persName>Mayor</persName></person><person xml:id="Montgomery_3H6"><persName>Montgomery</persName></person><person xml:id="SOLDIERS.YORK.0.1_3H6"><persName>Soldier</persName></person><person xml:id="SOLDIERS.YORK_3H6"><persName>Soldiers, Servants, Attendants, Drummers, Trumpeters, Sir Hugh Mortimer, Henry, Earl of Richmond, Aldermen of York, Mayor of Coventry, Nurse, the infant prince, and Others</persName></person><person xml:id="ALDERMEN_3H6"><persName>Soldiers, Servants, Attendants, Drummers, Trumpeters, Sir Hugh Mortimer, Henry, Earl of Richmond, Aldermen of York, Mayor of Coventry, Nurse, the infant prince, and Others</persName></person><person xml:id="SOLDIERS.MONTGOMERY_3H6"><persName>Soldiers, Servants, Attendants, Drummers, Trumpeters, Sir Hugh Mortimer, Henry, Earl of Richmond, Aldermen of York, Mayor of Coventry, Nurse, the infant prince, and Others</persName></person><person xml:id="MESSENGERS.1_3H6"><persName>First Messenger</persName></person><person xml:id="MESSENGERS.2_3H6"><persName>Second Messenger</persName></person><person xml:id="Somerville_3H6"><persName>Somerville</persName></person><person xml:id="MESSENGERS.X.5_3H6"><persName>MESSENGERS.X.5_3H6</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Warwick_2H6">
+            <persName>Warwick</persName>
+          </person>
+          <person xml:id="York_1H6">
+            <persName>York</persName>
+          </person>
+          <person xml:id="EdwardIV_3H6">
+            <persName>Edward King Edward IV</persName>
+            <persName>Edward King Edward IV</persName>
+          </person>
+          <person xml:id="Montague_3H6">
+            <persName>Montague</persName>
+          </person>
+          <person xml:id="RichardIII_R3">
+            <persName>Richard Gloucester</persName>
+            <persName>Richard Gloucester</persName>
+          </person>
+          <person xml:id="Norfolk_3H6">
+            <persName>Norfolk</persName>
+          </person>
+          <person xml:id="HenryVI_1H6">
+            <persName>King Henry VI</persName>
+          </person>
+          <person xml:id="Northumberland_3H6">
+            <persName>Northumberland</persName>
+          </person>
+          <person xml:id="Clifford_3H6">
+            <persName>Clifford</persName>
+          </person>
+          <person xml:id="Westmorland_3H6">
+            <persName>Westmorland</persName>
+          </person>
+          <person xml:id="Exeter_3H6">
+            <persName>Exeter</persName>
+          </person>
+          <person xml:id="QueenMargaret_1H6">
+            <persName>Queen Margaret</persName>
+          </person>
+          <person xml:id="PrinceEdward_3H6">
+            <persName>Prince Edward</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.1_3H6">
+            <persName>MESSENGERS.X.1_3H6</persName>
+          </person>
+          <person xml:id="JohnMortimer_3H6">
+            <persName>Sir John</persName>
+          </person>
+          <person xml:id="Rutland_3H6">
+            <persName>Rutland</persName>
+          </person>
+          <person xml:id="Tutor_3H6">
+            <persName>Tutor</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.2_3H6">
+            <persName>MESSENGERS.X.2_3H6</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.3_3H6">
+            <persName>MESSENGERS.X.3_3H6</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.4_3H6">
+            <persName>MESSENGERS.X.4_3H6</persName>
+          </person>
+          <person xml:id="Clarence_3H6">
+            <persName>George Clarence</persName>
+            <persName>George Clarence</persName>
+          </person>
+          <person xml:id="Son_3H6">
+            <persName>Son</persName>
+          </person>
+          <person xml:id="Father_3H6">
+            <persName>Father</persName>
+          </person>
+          <person xml:id="GAMEKEEPERS.1_3H6">
+            <persName>First Gamekeeper</persName>
+          </person>
+          <person xml:id="GAMEKEEPERS.2_3H6">
+            <persName>Second Gamekeeper</persName>
+          </person>
+          <person xml:id="QueenElizabeth_3H6">
+            <persName>Lady Grey Queen Elizabeth</persName>
+            <persName>Lady Grey Queen Elizabeth</persName>
+          </person>
+          <person xml:id="ATTENDANTS.EDWARD.1_3H6">
+            <persName>Nobleman</persName>
+          </person>
+          <person xml:id="KingLewis_3H6">
+            <persName>King Lewis</persName>
+          </person>
+          <person xml:id="Oxford_3H6">
+            <persName>Oxford</persName>
+          </person>
+          <person xml:id="LadyBona_3H6">
+            <persName>Lady Bona</persName>
+          </person>
+          <person xml:id="MESSENGERS.Post_3H6">
+            <persName>Post</persName>
+          </person>
+          <person xml:id="Somerset_3H6">
+            <persName>Somerset</persName>
+          </person>
+          <person xml:id="Hastings_3H6">
+            <persName>Hastings</persName>
+          </person>
+          <person xml:id="WATCHMEN.1_3H6">
+            <persName>First Watch</persName>
+          </person>
+          <person xml:id="WATCHMEN.2_3H6">
+            <persName>Second Watch</persName>
+          </person>
+          <person xml:id="WATCHMEN.3_3H6">
+            <persName>Third Watch</persName>
+          </person>
+          <person xml:id="Rivers_3H6">
+            <persName>Rivers</persName>
+          </person>
+          <person xml:id="Huntsman_3H6">
+            <persName>Huntsman</persName>
+          </person>
+          <person xml:id="Lieutenant_3H6">
+            <persName>Lieutenant</persName>
+          </person>
+          <person xml:id="MayorOfYork_3H6">
+            <persName>Mayor</persName>
+          </person>
+          <person xml:id="Montgomery_3H6">
+            <persName>Montgomery</persName>
+          </person>
+          <person xml:id="SOLDIERS.YORK.0.1_3H6">
+            <persName>Soldier</persName>
+          </person>
+          <person xml:id="SOLDIERS.YORK_3H6">
+            <persName>Soldiers, Servants, Attendants, Drummers, Trumpeters, Sir Hugh Mortimer, Henry, Earl of Richmond, Aldermen of York, Mayor of Coventry, Nurse, the infant prince, and Others</persName>
+          </person>
+          <person xml:id="ALDERMEN_3H6">
+            <persName>Soldiers, Servants, Attendants, Drummers, Trumpeters, Sir Hugh Mortimer, Henry, Earl of Richmond, Aldermen of York, Mayor of Coventry, Nurse, the infant prince, and Others</persName>
+          </person>
+          <person xml:id="SOLDIERS.MONTGOMERY_3H6">
+            <persName>Soldiers, Servants, Attendants, Drummers, Trumpeters, Sir Hugh Mortimer, Henry, Earl of Richmond, Aldermen of York, Mayor of Coventry, Nurse, the infant prince, and Others</persName>
+          </person>
+          <person xml:id="MESSENGERS.1_3H6">
+            <persName>First Messenger</persName>
+          </person>
+          <person xml:id="MESSENGERS.2_3H6">
+            <persName>Second Messenger</persName>
+          </person>
+          <person xml:id="Somerville_3H6">
+            <persName>Somerville</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.5_3H6">
+            <persName>MESSENGERS.X.5_3H6</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/henry-vi-part-3.xml
+++ b/tei/henry-vi-part-3.xml
@@ -88,157 +88,157 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Warwick_2H6">
+          <person xml:id="Warwick_2H6" ana="http://www.wikidata.org/entity/Q923162">
             <persName>Warwick</persName>
           </person>
-          <person xml:id="York_1H6">
+          <person xml:id="York_1H6" sex="MALE ">
             <persName>York</persName>
           </person>
-          <person xml:id="EdwardIV_3H6">
+          <person xml:id="EdwardIV_3H6" ana="http://www.wikidata.org/entity/Q160341">
             <persName>Edward King Edward IV</persName>
             <persName>Edward King Edward IV</persName>
           </person>
-          <person xml:id="Montague_3H6">
+          <person xml:id="Montague_3H6" sex="MALE ">
             <persName>Montague</persName>
           </person>
-          <person xml:id="RichardIII_R3">
+          <person xml:id="RichardIII_R3" ana="http://www.wikidata.org/entity/Q7323515">
             <persName>Richard Gloucester</persName>
             <persName>Richard Gloucester</persName>
           </person>
-          <person xml:id="Norfolk_3H6">
+          <person xml:id="Norfolk_3H6" sex="MALE ">
             <persName>Norfolk</persName>
           </person>
-          <person xml:id="HenryVI_1H6">
+          <person xml:id="HenryVI_1H6" ana="http://www.wikidata.org/entity/Q160337">
             <persName>King Henry VI</persName>
           </person>
-          <person xml:id="Northumberland_3H6">
+          <person xml:id="Northumberland_3H6" sex="MALE ">
             <persName>Northumberland</persName>
           </person>
-          <person xml:id="Clifford_3H6">
+          <person xml:id="Clifford_3H6" sex="MALE ">
             <persName>Clifford</persName>
           </person>
-          <person xml:id="Westmorland_3H6">
+          <person xml:id="Westmorland_3H6" ana="http://www.wikidata.org/entity/Q1972589">
             <persName>Westmorland</persName>
           </person>
-          <person xml:id="Exeter_3H6">
+          <person xml:id="Exeter_3H6" sex="MALE ">
             <persName>Exeter</persName>
           </person>
-          <person xml:id="QueenMargaret_1H6">
+          <person xml:id="QueenMargaret_1H6" ana="http://www.wikidata.org/entity/Q229159">
             <persName>Queen Margaret</persName>
           </person>
-          <person xml:id="PrinceEdward_3H6">
+          <person xml:id="PrinceEdward_3H6" sex="MALE ">
             <persName>Prince Edward</persName>
           </person>
-          <person xml:id="MESSENGERS.X.1_3H6">
-            <persName>MESSENGERS.X.1_3H6</persName>
-          </person>
-          <person xml:id="JohnMortimer_3H6">
+          <personGrp xml:id="MESSENGERS.X.1_3H6" sex="UNKNOWN">
+            <name>MESSENGERS.X.1_3H6</name>
+          </personGrp>
+          <person xml:id="JohnMortimer_3H6" sex="MALE">
             <persName>Sir John</persName>
           </person>
-          <person xml:id="Rutland_3H6">
+          <person xml:id="Rutland_3H6" sex="MALE">
             <persName>Rutland</persName>
           </person>
-          <person xml:id="Tutor_3H6">
+          <person xml:id="Tutor_3H6" sex="MALE">
             <persName>Tutor</persName>
           </person>
-          <person xml:id="MESSENGERS.X.2_3H6">
-            <persName>MESSENGERS.X.2_3H6</persName>
-          </person>
-          <person xml:id="MESSENGERS.X.3_3H6">
-            <persName>MESSENGERS.X.3_3H6</persName>
-          </person>
-          <person xml:id="MESSENGERS.X.4_3H6">
-            <persName>MESSENGERS.X.4_3H6</persName>
-          </person>
-          <person xml:id="Clarence_3H6">
+          <personGrp xml:id="MESSENGERS.X.2_3H6" sex="UNKNOWN">
+            <name>MESSENGERS.X.2_3H6</name>
+          </personGrp>
+          <personGrp xml:id="MESSENGERS.X.3_3H6" sex="UNKNOWN">
+            <name>MESSENGERS.X.3_3H6</name>
+          </personGrp>
+          <personGrp xml:id="MESSENGERS.X.4_3H6" sex="UNKNOWN">
+            <name>MESSENGERS.X.4_3H6</name>
+          </personGrp>
+          <person xml:id="Clarence_3H6" sex="MALE">
             <persName>George Clarence</persName>
             <persName>George Clarence</persName>
           </person>
-          <person xml:id="Son_3H6">
+          <person xml:id="Son_3H6" sex="MALE">
             <persName>Son</persName>
           </person>
-          <person xml:id="Father_3H6">
+          <person xml:id="Father_3H6" sex="MALE">
             <persName>Father</persName>
           </person>
-          <person xml:id="GAMEKEEPERS.1_3H6">
+          <person xml:id="GAMEKEEPERS.1_3H6" sex="MALE">
             <persName>First Gamekeeper</persName>
           </person>
-          <person xml:id="GAMEKEEPERS.2_3H6">
+          <person xml:id="GAMEKEEPERS.2_3H6" sex="MALE">
             <persName>Second Gamekeeper</persName>
           </person>
-          <person xml:id="QueenElizabeth_3H6">
+          <person xml:id="QueenElizabeth_3H6" sex="FEMALE">
             <persName>Lady Grey Queen Elizabeth</persName>
             <persName>Lady Grey Queen Elizabeth</persName>
           </person>
-          <person xml:id="ATTENDANTS.EDWARD.1_3H6">
+          <person xml:id="ATTENDANTS.EDWARD.1_3H6" sex="MALE">
             <persName>Nobleman</persName>
           </person>
-          <person xml:id="KingLewis_3H6">
+          <person xml:id="KingLewis_3H6" sex="MALE">
             <persName>King Lewis</persName>
           </person>
-          <person xml:id="Oxford_3H6">
+          <person xml:id="Oxford_3H6" sex="MALE">
             <persName>Oxford</persName>
           </person>
-          <person xml:id="LadyBona_3H6">
+          <person xml:id="LadyBona_3H6" sex="FEMALE">
             <persName>Lady Bona</persName>
           </person>
-          <person xml:id="MESSENGERS.Post_3H6">
+          <person xml:id="MESSENGERS.Post_3H6" sex="MALE">
             <persName>Post</persName>
           </person>
-          <person xml:id="Somerset_3H6">
+          <person xml:id="Somerset_3H6" sex="MALE">
             <persName>Somerset</persName>
           </person>
-          <person xml:id="Hastings_3H6">
+          <person xml:id="Hastings_3H6" sex="MALE">
             <persName>Hastings</persName>
           </person>
-          <person xml:id="WATCHMEN.1_3H6">
+          <person xml:id="WATCHMEN.1_3H6" sex="MALE">
             <persName>First Watch</persName>
           </person>
-          <person xml:id="WATCHMEN.2_3H6">
+          <person xml:id="WATCHMEN.2_3H6" sex="MALE">
             <persName>Second Watch</persName>
           </person>
-          <person xml:id="WATCHMEN.3_3H6">
+          <person xml:id="WATCHMEN.3_3H6" sex="MALE">
             <persName>Third Watch</persName>
           </person>
-          <person xml:id="Rivers_3H6">
+          <person xml:id="Rivers_3H6" sex="MALE">
             <persName>Rivers</persName>
           </person>
-          <person xml:id="Huntsman_3H6">
+          <person xml:id="Huntsman_3H6" sex="MALE">
             <persName>Huntsman</persName>
           </person>
-          <person xml:id="Lieutenant_3H6">
+          <person xml:id="Lieutenant_3H6" sex="MALE">
             <persName>Lieutenant</persName>
           </person>
-          <person xml:id="MayorOfYork_3H6">
+          <person xml:id="MayorOfYork_3H6" sex="MALE">
             <persName>Mayor</persName>
           </person>
-          <person xml:id="Montgomery_3H6">
+          <person xml:id="Montgomery_3H6" sex="MALE">
             <persName>Montgomery</persName>
           </person>
-          <person xml:id="SOLDIERS.YORK.0.1_3H6">
+          <person xml:id="SOLDIERS.YORK.0.1_3H6" sex="MALE">
             <persName>Soldier</persName>
           </person>
-          <person xml:id="SOLDIERS.YORK_3H6">
-            <persName>Soldiers, Servants, Attendants, Drummers, Trumpeters, Sir Hugh Mortimer, Henry, Earl of Richmond, Aldermen of York, Mayor of Coventry, Nurse, the infant prince, and Others</persName>
-          </person>
-          <person xml:id="ALDERMEN_3H6">
-            <persName>Soldiers, Servants, Attendants, Drummers, Trumpeters, Sir Hugh Mortimer, Henry, Earl of Richmond, Aldermen of York, Mayor of Coventry, Nurse, the infant prince, and Others</persName>
-          </person>
-          <person xml:id="SOLDIERS.MONTGOMERY_3H6">
-            <persName>Soldiers, Servants, Attendants, Drummers, Trumpeters, Sir Hugh Mortimer, Henry, Earl of Richmond, Aldermen of York, Mayor of Coventry, Nurse, the infant prince, and Others</persName>
-          </person>
-          <person xml:id="MESSENGERS.1_3H6">
+          <personGrp xml:id="SOLDIERS.YORK_3H6" sex="UNKNOWN">
+            <name>Soldiers, Servants, Attendants, Drummers, Trumpeters, Sir Hugh Mortimer, Henry, Earl of Richmond, Aldermen of York, Mayor of Coventry, Nurse, the infant prince, and Others</name>
+          </personGrp>
+          <personGrp xml:id="ALDERMEN_3H6" sex="UNKNOWN">
+            <name>Soldiers, Servants, Attendants, Drummers, Trumpeters, Sir Hugh Mortimer, Henry, Earl of Richmond, Aldermen of York, Mayor of Coventry, Nurse, the infant prince, and Others</name>
+          </personGrp>
+          <personGrp xml:id="SOLDIERS.MONTGOMERY_3H6" sex="UNKNOWN">
+            <name>Soldiers, Servants, Attendants, Drummers, Trumpeters, Sir Hugh Mortimer, Henry, Earl of Richmond, Aldermen of York, Mayor of Coventry, Nurse, the infant prince, and Others</name>
+          </personGrp>
+          <person xml:id="MESSENGERS.1_3H6" sex="MALE">
             <persName>First Messenger</persName>
           </person>
-          <person xml:id="MESSENGERS.2_3H6">
+          <person xml:id="MESSENGERS.2_3H6" sex="MALE">
             <persName>Second Messenger</persName>
           </person>
-          <person xml:id="Somerville_3H6">
+          <person xml:id="Somerville_3H6" sex="MALE">
             <persName>Somerville</persName>
           </person>
-          <person xml:id="MESSENGERS.X.5_3H6">
-            <persName>MESSENGERS.X.5_3H6</persName>
-          </person>
+          <personGrp xml:id="MESSENGERS.X.5_3H6" sex="UNKNOWN">
+            <name>MESSENGERS.X.5_3H6</name>
+          </personGrp>
         </listPerson>
       </particDesc>
     </profileDesc>

--- a/tei/henry-viii.xml
+++ b/tei/henry-viii.xml
@@ -88,7 +88,7 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person sex="" xml:id="Prologue_H8">
+          <person xml:id="Prologue_H8">
             <persName>Prologue</persName>
           </person>
           <person xml:id="Buckingham_H8" sex="MALE">
@@ -229,7 +229,7 @@
           <person xml:id="Garter_H8" sex="MALE">
             <persName>Garter King of Arms</persName>
           </person>
-          <person sex="" xml:id="Epilogue_H8">
+          <person xml:id="Epilogue_H8">
             <persName>Epilogue</persName>
           </person>
         </listPerson>

--- a/tei/henry-viii.xml
+++ b/tei/henry-viii.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,155 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Prologue_H8"><persName>Prologue</persName></person><person xml:id="Buckingham_H8"><persName>Duke of Buckingham</persName></person><person xml:id="Norfolk_H8"><persName>Duke of Norfolk</persName></person><person xml:id="Abergavenny_H8"><persName>Lord Abergavenny</persName></person><person xml:id="Wolsey_H8"><persName>Cardinal Wolsey</persName></person><person xml:id="SECRETARIES.0.1_H8"><persName>SECRETARIES.0.1_H8</persName></person><person xml:id="Brandon_H8"><persName>Brandon</persName></person><person xml:id="Sergeant_H8"><persName>Sergeant at Arms</persName></person><person xml:id="HenryVIII_H8"><persName>King Henry the Eighth</persName></person><person xml:id="Katherine_H8"><persName>Queen Katherine</persName></person><person xml:id="Surveyor_H8"><persName>Knevet, former Surveyor to Buckingham</persName></person><person xml:id="Chamberlain_H8"><persName>Lord Chamberlain</persName></person><person xml:id="Sands_H8"><persName>Lord Sands (also Sir Walter Sands)</persName></person><person xml:id="Lovell_H8"><persName>Sir Thomas Lovell</persName></person><person xml:id="Guilford_H8"><persName>Sir Henry Guilford</persName></person><person xml:id="Anne_H8"><persName>Anne Bullen</persName></person><person xml:id="SERVANTS.X.1_H8"><persName>Spirits, Princess Elizabeth as an infant, Duchess of Norfolk, Marquess and Marchioness of Dorset, Lords, Nobles, Countesses, Bishops, Judges, Priests, Ladies, Gentlemen, Gentlemen Ushers, Lord Mayor, Four Representatives of the Cinque Ports, Aldermen, Women, Musicians, Choristers, Guards, Tipstaves, Halberds, Vergers, Attendants, Servants, Messenger, Pages, Footboys, Grooms</persName></person><person xml:id="GENTLEMEN.1_H8"><persName>First Gentleman</persName></person><person xml:id="GENTLEMEN.2_H8"><persName>Second Gentleman</persName></person><person xml:id="Vaux_H8"><persName>Sir Nicholas Vaux</persName></person><person xml:id="Suffolk_H8"><persName>Duke of Suffolk</persName></person><person xml:id="Campeius_H8"><persName>Cardinal Campeius</persName></person><person xml:id="Gardiner_H8"><persName>Gardiner</persName></person><person xml:id="OldLady_H8"><persName>Old Lady</persName></person><person xml:id="Scribe_H8"><persName>Scribes</persName></person><person xml:id="Crier_H8"><persName>Crier</persName></person><person xml:id="Usher_H8"><persName>Queen’s Gentleman Usher</persName></person><person xml:id="BishopOfLincoln_H8"><persName>Bishop of Lincoln</persName></person><person xml:id="LADIES.KATHERINE.0.1_H8"><persName>Spirits, Princess Elizabeth as an infant, Duchess of Norfolk, Marquess and Marchioness of Dorset, Lords, Nobles, Countesses, Bishops, Judges, Priests, Ladies, Gentlemen, Gentlemen Ushers, Lord Mayor, Four Representatives of the Cinque Ports, Aldermen, Women, Musicians, Choristers, Guards, Tipstaves, Halberds, Vergers, Attendants, Servants, Messenger, Pages, Footboys, Grooms</persName></person><person xml:id="GENTLEMEN.X_H8"><persName>Spirits, Princess Elizabeth as an infant, Duchess of Norfolk, Marquess and Marchioness of Dorset, Lords, Nobles, Countesses, Bishops, Judges, Priests, Ladies, Gentlemen, Gentlemen Ushers, Lord Mayor, Four Representatives of the Cinque Ports, Aldermen, Women, Musicians, Choristers, Guards, Tipstaves, Halberds, Vergers, Attendants, Servants, Messenger, Pages, Footboys, Grooms</persName></person><person xml:id="Surrey_H8"><persName>Earl of Surrey</persName></person><person xml:id="Cromwell_H8"><persName>Cromwell</persName></person><person xml:id="GENTLEMEN.3_H8"><persName>Third Gentleman</persName></person><person xml:id="Griffith_H8"><persName>Griffith</persName></person><person xml:id="LADIES.KATHERINE.Patience_H8"><persName>Patience</persName></person><person xml:id="Messenger_H8"><persName>Spirits, Princess Elizabeth as an infant, Duchess of Norfolk, Marquess and Marchioness of Dorset, Lords, Nobles, Countesses, Bishops, Judges, Priests, Ladies, Gentlemen, Gentlemen Ushers, Lord Mayor, Four Representatives of the Cinque Ports, Aldermen, Women, Musicians, Choristers, Guards, Tipstaves, Halberds, Vergers, Attendants, Servants, Messenger, Pages, Footboys, Grooms</persName></person><person xml:id="Capuchius_H8"><persName>Capuchius</persName></person><person xml:id="Page_H8"><persName>Page to Gardiner</persName></person><person xml:id="Denny_H8"><persName>Sir Anthony Denny</persName></person><person xml:id="Cranmer_H8"><persName>Cranmer</persName></person><person xml:id="Keeper_H8"><persName>Keeper</persName></person><person xml:id="Butts_H8"><persName>Doctor Butts</persName></person><person xml:id="Chancellor_H8"><persName>Lord Chancellor</persName></person><person xml:id="Porter_H8"><persName>Porter and his Man</persName></person><person xml:id="SERVANTS.LARDER.1_H8"><persName>Spirits, Princess Elizabeth as an infant, Duchess of Norfolk, Marquess and Marchioness of Dorset, Lords, Nobles, Countesses, Bishops, Judges, Priests, Ladies, Gentlemen, Gentlemen Ushers, Lord Mayor, Four Representatives of the Cinque Ports, Aldermen, Women, Musicians, Choristers, Guards, Tipstaves, Halberds, Vergers, Attendants, Servants, Messenger, Pages, Footboys, Grooms</persName></person><person xml:id="SERVANTS.PORTER.1_H8"><persName>Porter and his Man</persName></person><person xml:id="Garter_H8"><persName>Garter King of Arms</persName></person><person xml:id="Epilogue_H8"><persName>Epilogue</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Prologue_H8">
+            <persName>Prologue</persName>
+          </person>
+          <person xml:id="Buckingham_H8">
+            <persName>Duke of Buckingham</persName>
+          </person>
+          <person xml:id="Norfolk_H8">
+            <persName>Duke of Norfolk</persName>
+          </person>
+          <person xml:id="Abergavenny_H8">
+            <persName>Lord Abergavenny</persName>
+          </person>
+          <person xml:id="Wolsey_H8">
+            <persName>Cardinal Wolsey</persName>
+          </person>
+          <person xml:id="SECRETARIES.0.1_H8">
+            <persName>SECRETARIES.0.1_H8</persName>
+          </person>
+          <person xml:id="Brandon_H8">
+            <persName>Brandon</persName>
+          </person>
+          <person xml:id="Sergeant_H8">
+            <persName>Sergeant at Arms</persName>
+          </person>
+          <person xml:id="HenryVIII_H8">
+            <persName>King Henry the Eighth</persName>
+          </person>
+          <person xml:id="Katherine_H8">
+            <persName>Queen Katherine</persName>
+          </person>
+          <person xml:id="Surveyor_H8">
+            <persName>Knevet, former Surveyor to Buckingham</persName>
+          </person>
+          <person xml:id="Chamberlain_H8">
+            <persName>Lord Chamberlain</persName>
+          </person>
+          <person xml:id="Sands_H8">
+            <persName>Lord Sands (also Sir Walter Sands)</persName>
+          </person>
+          <person xml:id="Lovell_H8">
+            <persName>Sir Thomas Lovell</persName>
+          </person>
+          <person xml:id="Guilford_H8">
+            <persName>Sir Henry Guilford</persName>
+          </person>
+          <person xml:id="Anne_H8">
+            <persName>Anne Bullen</persName>
+          </person>
+          <person xml:id="SERVANTS.X.1_H8">
+            <persName>Spirits, Princess Elizabeth as an infant, Duchess of Norfolk, Marquess and Marchioness of Dorset, Lords, Nobles, Countesses, Bishops, Judges, Priests, Ladies, Gentlemen, Gentlemen Ushers, Lord Mayor, Four Representatives of the Cinque Ports, Aldermen, Women, Musicians, Choristers, Guards, Tipstaves, Halberds, Vergers, Attendants, Servants, Messenger, Pages, Footboys, Grooms</persName>
+          </person>
+          <person xml:id="GENTLEMEN.1_H8">
+            <persName>First Gentleman</persName>
+          </person>
+          <person xml:id="GENTLEMEN.2_H8">
+            <persName>Second Gentleman</persName>
+          </person>
+          <person xml:id="Vaux_H8">
+            <persName>Sir Nicholas Vaux</persName>
+          </person>
+          <person xml:id="Suffolk_H8">
+            <persName>Duke of Suffolk</persName>
+          </person>
+          <person xml:id="Campeius_H8">
+            <persName>Cardinal Campeius</persName>
+          </person>
+          <person xml:id="Gardiner_H8">
+            <persName>Gardiner</persName>
+          </person>
+          <person xml:id="OldLady_H8">
+            <persName>Old Lady</persName>
+          </person>
+          <person xml:id="Scribe_H8">
+            <persName>Scribes</persName>
+          </person>
+          <person xml:id="Crier_H8">
+            <persName>Crier</persName>
+          </person>
+          <person xml:id="Usher_H8">
+            <persName>Queen’s Gentleman Usher</persName>
+          </person>
+          <person xml:id="BishopOfLincoln_H8">
+            <persName>Bishop of Lincoln</persName>
+          </person>
+          <person xml:id="LADIES.KATHERINE.0.1_H8">
+            <persName>Spirits, Princess Elizabeth as an infant, Duchess of Norfolk, Marquess and Marchioness of Dorset, Lords, Nobles, Countesses, Bishops, Judges, Priests, Ladies, Gentlemen, Gentlemen Ushers, Lord Mayor, Four Representatives of the Cinque Ports, Aldermen, Women, Musicians, Choristers, Guards, Tipstaves, Halberds, Vergers, Attendants, Servants, Messenger, Pages, Footboys, Grooms</persName>
+          </person>
+          <person xml:id="GENTLEMEN.X_H8">
+            <persName>Spirits, Princess Elizabeth as an infant, Duchess of Norfolk, Marquess and Marchioness of Dorset, Lords, Nobles, Countesses, Bishops, Judges, Priests, Ladies, Gentlemen, Gentlemen Ushers, Lord Mayor, Four Representatives of the Cinque Ports, Aldermen, Women, Musicians, Choristers, Guards, Tipstaves, Halberds, Vergers, Attendants, Servants, Messenger, Pages, Footboys, Grooms</persName>
+          </person>
+          <person xml:id="Surrey_H8">
+            <persName>Earl of Surrey</persName>
+          </person>
+          <person xml:id="Cromwell_H8">
+            <persName>Cromwell</persName>
+          </person>
+          <person xml:id="GENTLEMEN.3_H8">
+            <persName>Third Gentleman</persName>
+          </person>
+          <person xml:id="Griffith_H8">
+            <persName>Griffith</persName>
+          </person>
+          <person xml:id="LADIES.KATHERINE.Patience_H8">
+            <persName>Patience</persName>
+          </person>
+          <person xml:id="Messenger_H8">
+            <persName>Spirits, Princess Elizabeth as an infant, Duchess of Norfolk, Marquess and Marchioness of Dorset, Lords, Nobles, Countesses, Bishops, Judges, Priests, Ladies, Gentlemen, Gentlemen Ushers, Lord Mayor, Four Representatives of the Cinque Ports, Aldermen, Women, Musicians, Choristers, Guards, Tipstaves, Halberds, Vergers, Attendants, Servants, Messenger, Pages, Footboys, Grooms</persName>
+          </person>
+          <person xml:id="Capuchius_H8">
+            <persName>Capuchius</persName>
+          </person>
+          <person xml:id="Page_H8">
+            <persName>Page to Gardiner</persName>
+          </person>
+          <person xml:id="Denny_H8">
+            <persName>Sir Anthony Denny</persName>
+          </person>
+          <person xml:id="Cranmer_H8">
+            <persName>Cranmer</persName>
+          </person>
+          <person xml:id="Keeper_H8">
+            <persName>Keeper</persName>
+          </person>
+          <person xml:id="Butts_H8">
+            <persName>Doctor Butts</persName>
+          </person>
+          <person xml:id="Chancellor_H8">
+            <persName>Lord Chancellor</persName>
+          </person>
+          <person xml:id="Porter_H8">
+            <persName>Porter and his Man</persName>
+          </person>
+          <person xml:id="SERVANTS.LARDER.1_H8">
+            <persName>Spirits, Princess Elizabeth as an infant, Duchess of Norfolk, Marquess and Marchioness of Dorset, Lords, Nobles, Countesses, Bishops, Judges, Priests, Ladies, Gentlemen, Gentlemen Ushers, Lord Mayor, Four Representatives of the Cinque Ports, Aldermen, Women, Musicians, Choristers, Guards, Tipstaves, Halberds, Vergers, Attendants, Servants, Messenger, Pages, Footboys, Grooms</persName>
+          </person>
+          <person xml:id="SERVANTS.PORTER.1_H8">
+            <persName>Porter and his Man</persName>
+          </person>
+          <person xml:id="Garter_H8">
+            <persName>Garter King of Arms</persName>
+          </person>
+          <person xml:id="Epilogue_H8">
+            <persName>Epilogue</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/henry-viii.xml
+++ b/tei/henry-viii.xml
@@ -88,148 +88,148 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Prologue_H8">
+          <person sex="" xml:id="Prologue_H8">
             <persName>Prologue</persName>
           </person>
-          <person xml:id="Buckingham_H8">
+          <person xml:id="Buckingham_H8" sex="MALE">
             <persName>Duke of Buckingham</persName>
           </person>
-          <person xml:id="Norfolk_H8">
+          <person xml:id="Norfolk_H8" sex="MALE">
             <persName>Duke of Norfolk</persName>
           </person>
-          <person xml:id="Abergavenny_H8">
+          <person xml:id="Abergavenny_H8" sex="MALE">
             <persName>Lord Abergavenny</persName>
           </person>
-          <person xml:id="Wolsey_H8">
+          <person xml:id="Wolsey_H8" sex="MALE">
             <persName>Cardinal Wolsey</persName>
           </person>
-          <person xml:id="SECRETARIES.0.1_H8">
+          <person xml:id="SECRETARIES.0.1_H8" sex="MALE">
             <persName>SECRETARIES.0.1_H8</persName>
           </person>
-          <person xml:id="Brandon_H8">
+          <person xml:id="Brandon_H8" sex="MALE">
             <persName>Brandon</persName>
           </person>
-          <person xml:id="Sergeant_H8">
+          <person xml:id="Sergeant_H8" sex="MALE">
             <persName>Sergeant at Arms</persName>
           </person>
-          <person xml:id="HenryVIII_H8">
+          <person xml:id="HenryVIII_H8" ana="http://www.wikidata.org/entity/Q38370">
             <persName>King Henry the Eighth</persName>
           </person>
-          <person xml:id="Katherine_H8">
+          <person xml:id="Katherine_H8" sex="FEMALE">
             <persName>Queen Katherine</persName>
           </person>
-          <person xml:id="Surveyor_H8">
+          <person xml:id="Surveyor_H8" sex="MALE">
             <persName>Knevet, former Surveyor to Buckingham</persName>
           </person>
-          <person xml:id="Chamberlain_H8">
+          <person xml:id="Chamberlain_H8" sex="MALE">
             <persName>Lord Chamberlain</persName>
           </person>
-          <person xml:id="Sands_H8">
+          <person xml:id="Sands_H8" sex="MALE">
             <persName>Lord Sands (also Sir Walter Sands)</persName>
           </person>
-          <person xml:id="Lovell_H8">
+          <person xml:id="Lovell_H8" sex="MALE">
             <persName>Sir Thomas Lovell</persName>
           </person>
-          <person xml:id="Guilford_H8">
+          <person xml:id="Guilford_H8" sex="MALE">
             <persName>Sir Henry Guilford</persName>
           </person>
-          <person xml:id="Anne_H8">
+          <person xml:id="Anne_H8" ana="http://www.wikidata.org/entity/Q80823">
             <persName>Anne Bullen</persName>
           </person>
-          <person xml:id="SERVANTS.X.1_H8">
+          <person xml:id="SERVANTS.X.1_H8" sex="UNKNOWN">
             <persName>Spirits, Princess Elizabeth as an infant, Duchess of Norfolk, Marquess and Marchioness of Dorset, Lords, Nobles, Countesses, Bishops, Judges, Priests, Ladies, Gentlemen, Gentlemen Ushers, Lord Mayor, Four Representatives of the Cinque Ports, Aldermen, Women, Musicians, Choristers, Guards, Tipstaves, Halberds, Vergers, Attendants, Servants, Messenger, Pages, Footboys, Grooms</persName>
           </person>
-          <person xml:id="GENTLEMEN.1_H8">
+          <person xml:id="GENTLEMEN.1_H8" sex="MALE">
             <persName>First Gentleman</persName>
           </person>
-          <person xml:id="GENTLEMEN.2_H8">
+          <person xml:id="GENTLEMEN.2_H8" sex="MALE">
             <persName>Second Gentleman</persName>
           </person>
-          <person xml:id="Vaux_H8">
+          <person xml:id="Vaux_H8" sex="MALE">
             <persName>Sir Nicholas Vaux</persName>
           </person>
-          <person xml:id="Suffolk_H8">
+          <person xml:id="Suffolk_H8" sex="MALE">
             <persName>Duke of Suffolk</persName>
           </person>
-          <person xml:id="Campeius_H8">
+          <person xml:id="Campeius_H8" ana="http://www.wikidata.org/entity/Q222941">
             <persName>Cardinal Campeius</persName>
           </person>
-          <person xml:id="Gardiner_H8">
+          <person xml:id="Gardiner_H8" sex="MALE">
             <persName>Gardiner</persName>
           </person>
-          <person xml:id="OldLady_H8">
+          <person xml:id="OldLady_H8" sex="FEMALE">
             <persName>Old Lady</persName>
           </person>
-          <person xml:id="Scribe_H8">
+          <person xml:id="Scribe_H8" sex="MALE">
             <persName>Scribes</persName>
           </person>
-          <person xml:id="Crier_H8">
+          <person xml:id="Crier_H8" sex="MALE">
             <persName>Crier</persName>
           </person>
-          <person xml:id="Usher_H8">
+          <person xml:id="Usher_H8" sex="MALE">
             <persName>Queen’s Gentleman Usher</persName>
           </person>
-          <person xml:id="BishopOfLincoln_H8">
+          <person xml:id="BishopOfLincoln_H8" sex="MALE">
             <persName>Bishop of Lincoln</persName>
           </person>
-          <person xml:id="LADIES.KATHERINE.0.1_H8">
-            <persName>Spirits, Princess Elizabeth as an infant, Duchess of Norfolk, Marquess and Marchioness of Dorset, Lords, Nobles, Countesses, Bishops, Judges, Priests, Ladies, Gentlemen, Gentlemen Ushers, Lord Mayor, Four Representatives of the Cinque Ports, Aldermen, Women, Musicians, Choristers, Guards, Tipstaves, Halberds, Vergers, Attendants, Servants, Messenger, Pages, Footboys, Grooms</persName>
-          </person>
-          <person xml:id="GENTLEMEN.X_H8">
-            <persName>Spirits, Princess Elizabeth as an infant, Duchess of Norfolk, Marquess and Marchioness of Dorset, Lords, Nobles, Countesses, Bishops, Judges, Priests, Ladies, Gentlemen, Gentlemen Ushers, Lord Mayor, Four Representatives of the Cinque Ports, Aldermen, Women, Musicians, Choristers, Guards, Tipstaves, Halberds, Vergers, Attendants, Servants, Messenger, Pages, Footboys, Grooms</persName>
-          </person>
-          <person xml:id="Surrey_H8">
+          <personGrp xml:id="LADIES.KATHERINE.0.1_H8" sex="UNKNOWN">
+            <name>Spirits, Princess Elizabeth as an infant, Duchess of Norfolk, Marquess and Marchioness of Dorset, Lords, Nobles, Countesses, Bishops, Judges, Priests, Ladies, Gentlemen, Gentlemen Ushers, Lord Mayor, Four Representatives of the Cinque Ports, Aldermen, Women, Musicians, Choristers, Guards, Tipstaves, Halberds, Vergers, Attendants, Servants, Messenger, Pages, Footboys, Grooms</name>
+          </personGrp>
+          <personGrp xml:id="GENTLEMEN.X_H8" sex="UNKNOWN">
+            <name>Spirits, Princess Elizabeth as an infant, Duchess of Norfolk, Marquess and Marchioness of Dorset, Lords, Nobles, Countesses, Bishops, Judges, Priests, Ladies, Gentlemen, Gentlemen Ushers, Lord Mayor, Four Representatives of the Cinque Ports, Aldermen, Women, Musicians, Choristers, Guards, Tipstaves, Halberds, Vergers, Attendants, Servants, Messenger, Pages, Footboys, Grooms</name>
+          </personGrp>
+          <person xml:id="Surrey_H8" sex="MALE">
             <persName>Earl of Surrey</persName>
           </person>
-          <person xml:id="Cromwell_H8">
+          <person xml:id="Cromwell_H8" ana="http://www.wikidata.org/entity/Q44279">
             <persName>Cromwell</persName>
           </person>
-          <person xml:id="GENTLEMEN.3_H8">
+          <person xml:id="GENTLEMEN.3_H8" sex="MALE">
             <persName>Third Gentleman</persName>
           </person>
-          <person xml:id="Griffith_H8">
+          <person xml:id="Griffith_H8" sex="MALE">
             <persName>Griffith</persName>
           </person>
-          <person xml:id="LADIES.KATHERINE.Patience_H8">
+          <person xml:id="LADIES.KATHERINE.Patience_H8" sex="FEMALE">
             <persName>Patience</persName>
           </person>
-          <person xml:id="Messenger_H8">
-            <persName>Spirits, Princess Elizabeth as an infant, Duchess of Norfolk, Marquess and Marchioness of Dorset, Lords, Nobles, Countesses, Bishops, Judges, Priests, Ladies, Gentlemen, Gentlemen Ushers, Lord Mayor, Four Representatives of the Cinque Ports, Aldermen, Women, Musicians, Choristers, Guards, Tipstaves, Halberds, Vergers, Attendants, Servants, Messenger, Pages, Footboys, Grooms</persName>
-          </person>
-          <person xml:id="Capuchius_H8">
+          <personGrp xml:id="Messenger_H8" sex="UNKNOWN">
+            <name>Spirits, Princess Elizabeth as an infant, Duchess of Norfolk, Marquess and Marchioness of Dorset, Lords, Nobles, Countesses, Bishops, Judges, Priests, Ladies, Gentlemen, Gentlemen Ushers, Lord Mayor, Four Representatives of the Cinque Ports, Aldermen, Women, Musicians, Choristers, Guards, Tipstaves, Halberds, Vergers, Attendants, Servants, Messenger, Pages, Footboys, Grooms</name>
+          </personGrp>
+          <person xml:id="Capuchius_H8" sex="MALE">
             <persName>Capuchius</persName>
           </person>
-          <person xml:id="Page_H8">
+          <person xml:id="Page_H8" sex="FEMALE">
             <persName>Page to Gardiner</persName>
           </person>
-          <person xml:id="Denny_H8">
+          <person xml:id="Denny_H8" sex="MALE">
             <persName>Sir Anthony Denny</persName>
           </person>
-          <person xml:id="Cranmer_H8">
+          <person xml:id="Cranmer_H8" sex="MALE">
             <persName>Cranmer</persName>
           </person>
-          <person xml:id="Keeper_H8">
+          <person xml:id="Keeper_H8" sex="MALE">
             <persName>Keeper</persName>
           </person>
-          <person xml:id="Butts_H8">
+          <person xml:id="Butts_H8" sex="MALE">
             <persName>Doctor Butts</persName>
           </person>
-          <person xml:id="Chancellor_H8">
+          <person xml:id="Chancellor_H8" sex="MALE">
             <persName>Lord Chancellor</persName>
           </person>
-          <person xml:id="Porter_H8">
+          <person xml:id="Porter_H8" sex="MALE">
             <persName>Porter and his Man</persName>
           </person>
-          <person xml:id="SERVANTS.LARDER.1_H8">
+          <person xml:id="SERVANTS.LARDER.1_H8" sex="UNKNOWN">
             <persName>Spirits, Princess Elizabeth as an infant, Duchess of Norfolk, Marquess and Marchioness of Dorset, Lords, Nobles, Countesses, Bishops, Judges, Priests, Ladies, Gentlemen, Gentlemen Ushers, Lord Mayor, Four Representatives of the Cinque Ports, Aldermen, Women, Musicians, Choristers, Guards, Tipstaves, Halberds, Vergers, Attendants, Servants, Messenger, Pages, Footboys, Grooms</persName>
           </person>
-          <person xml:id="SERVANTS.PORTER.1_H8">
+          <person xml:id="SERVANTS.PORTER.1_H8" sex="MALE">
             <persName>Porter and his Man</persName>
           </person>
-          <person xml:id="Garter_H8">
+          <person xml:id="Garter_H8" sex="MALE">
             <persName>Garter King of Arms</persName>
           </person>
-          <person xml:id="Epilogue_H8">
+          <person sex="" xml:id="Epilogue_H8">
             <persName>Epilogue</persName>
           </person>
         </listPerson>

--- a/tei/julius-caesar.xml
+++ b/tei/julius-caesar.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,164 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Flavius_JC"><persName>Flavius</persName></person><person xml:id="COMMONERS.Carpenter_JC"><persName>COMMONERS.Carpenter_JC</persName></person><person xml:id="Marullus_JC"><persName>Marullus</persName></person><person xml:id="COMMONERS.Cobbler_JC"><persName>COMMONERS.Cobbler_JC</persName></person><person xml:id="Caesar_JC"><persName>Julius Caesar</persName></person><person xml:id="Casca_JC"><persName>Casca</persName></person><person xml:id="Calphurnia_JC"><persName>Calphurnia</persName></person><person xml:id="Antony_JC"><persName>Mark Antony</persName></person><person xml:id="Soothsayer_JC"><persName>Soothsayer_JC</persName></person><person xml:id="Brutus_JC"><persName>Marcus Brutus</persName></person><person xml:id="Cassius_JC"><persName>Caius Cassius</persName></person><person xml:id="Cicero_JC"><persName>Cicero</persName></person><person xml:id="Cinna_JC"><persName>Cinna</persName></person><person xml:id="Lucius_JC"><persName>Lucius</persName></person><person xml:id="Decius_JC"><persName>Decius Brutus</persName></person><person xml:id="Metellus_JC"><persName>Metellus Cimber</persName></person><person xml:id="Trebonius_JC"><persName>Trebonius</persName></person><person xml:id="Portia_JC"><persName>Portia</persName></person><person xml:id="Ligarius_JC"><persName>Caius Ligarius</persName></person><person xml:id="SERVANTS.CAESAR.1_JC"><persName>SERVANTS.CAESAR.1_JC</persName></person><person xml:id="Publius_JC"><persName>Publius</persName></person><person xml:id="Artemidorus_JC"><persName>Artemidorus</persName></person><person xml:id="Popilius_JC"><persName>Popilius Lena</persName></person><person xml:id="SERVANTS.ANTONY.1_JC"><persName>SERVANTS.ANTONY.1_JC</persName></person><person xml:id="SERVANTS.OCTAVIUS.1_JC"><persName>SERVANTS.OCTAVIUS.1_JC</persName></person><person xml:id="PLEBEIANS_JC"><persName>First, Second, Third, and Fourth Plebeians</persName></person><person xml:id="PLEBEIANS.0.1_JC"><persName>PLEBEIANS.0.1_JC</persName></person><person xml:id="PLEBEIANS.0.2_JC"><persName>PLEBEIANS.0.2_JC</persName></person><person xml:id="PLEBEIANS.0.3_JC"><persName>PLEBEIANS.0.3_JC</persName></person><person xml:id="PLEBEIANS.0.4_JC"><persName>PLEBEIANS.0.4_JC</persName></person><person xml:id="CinnaPoet_JC"><persName>Cinna</persName></person><person xml:id="Octavius_JC"><persName>Octavius</persName></person><person xml:id="Lepidus_JC"><persName>Lepidus</persName></person><person xml:id="SOLDIERS.BRUTUS.Lucilius_JC"><persName>Lucilius</persName></person><person xml:id="Pindarus_JC"><persName>Pindarus</persName></person><person xml:id="SOLDIERS.BRUTUS.0.1_JC"><persName>SOLDIERS.BRUTUS.0.1_JC</persName></person><person xml:id="SOLDIERS.BRUTUS.0.2_JC"><persName>SOLDIERS.BRUTUS.0.2_JC</persName></person><person xml:id="SOLDIERS.BRUTUS.0.3_JC"><persName>SOLDIERS.BRUTUS.0.3_JC</persName></person><person xml:id="Poet_JC"><persName>Poet_JC</persName></person><person xml:id="SOLDIERS.BRUTUS.Messala_JC"><persName>Messala</persName></person><person xml:id="SOLDIERS.BRUTUS.Titinius_JC"><persName>Titinius</persName></person><person xml:id="SOLDIERS.BRUTUS.Varro_JC"><persName>Varro</persName></person><person xml:id="SOLDIERS.BRUTUS.Claudius_JC"><persName>Claudius</persName></person><person xml:id="Messenger_JC"><persName>Messenger_JC</persName></person><person xml:id="SOLDIERS.BRUTUS.Cato_JC"><persName>Young Cato</persName></person><person xml:id="SOLDIERS.ANTONY.0.1_JC"><persName>SOLDIERS.ANTONY.0.1_JC</persName></person><person xml:id="SOLDIERS.ANTONY.0.2_JC"><persName>SOLDIERS.ANTONY.0.2_JC</persName></person><person xml:id="SOLDIERS.BRUTUS.Clitus_JC"><persName>Clitus</persName></person><person xml:id="SOLDIERS.BRUTUS.Dardanus_JC"><persName>Dardanus</persName></person><person xml:id="SOLDIERS.BRUTUS.Volumnius_JC"><persName>Volumnius</persName></person><person xml:id="SOLDIERS.BRUTUS.Strato_JC"><persName>Strato</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Flavius_JC">
+            <persName>Flavius</persName>
+          </person>
+          <person xml:id="COMMONERS.Carpenter_JC">
+            <persName>COMMONERS.Carpenter_JC</persName>
+          </person>
+          <person xml:id="Marullus_JC">
+            <persName>Marullus</persName>
+          </person>
+          <person xml:id="COMMONERS.Cobbler_JC">
+            <persName>COMMONERS.Cobbler_JC</persName>
+          </person>
+          <person xml:id="Caesar_JC">
+            <persName>Julius Caesar</persName>
+          </person>
+          <person xml:id="Casca_JC">
+            <persName>Casca</persName>
+          </person>
+          <person xml:id="Calphurnia_JC">
+            <persName>Calphurnia</persName>
+          </person>
+          <person xml:id="Antony_JC">
+            <persName>Mark Antony</persName>
+          </person>
+          <person xml:id="Soothsayer_JC">
+            <persName>Soothsayer_JC</persName>
+          </person>
+          <person xml:id="Brutus_JC">
+            <persName>Marcus Brutus</persName>
+          </person>
+          <person xml:id="Cassius_JC">
+            <persName>Caius Cassius</persName>
+          </person>
+          <person xml:id="Cicero_JC">
+            <persName>Cicero</persName>
+          </person>
+          <person xml:id="Cinna_JC">
+            <persName>Cinna</persName>
+          </person>
+          <person xml:id="Lucius_JC">
+            <persName>Lucius</persName>
+          </person>
+          <person xml:id="Decius_JC">
+            <persName>Decius Brutus</persName>
+          </person>
+          <person xml:id="Metellus_JC">
+            <persName>Metellus Cimber</persName>
+          </person>
+          <person xml:id="Trebonius_JC">
+            <persName>Trebonius</persName>
+          </person>
+          <person xml:id="Portia_JC">
+            <persName>Portia</persName>
+          </person>
+          <person xml:id="Ligarius_JC">
+            <persName>Caius Ligarius</persName>
+          </person>
+          <person xml:id="SERVANTS.CAESAR.1_JC">
+            <persName>SERVANTS.CAESAR.1_JC</persName>
+          </person>
+          <person xml:id="Publius_JC">
+            <persName>Publius</persName>
+          </person>
+          <person xml:id="Artemidorus_JC">
+            <persName>Artemidorus</persName>
+          </person>
+          <person xml:id="Popilius_JC">
+            <persName>Popilius Lena</persName>
+          </person>
+          <person xml:id="SERVANTS.ANTONY.1_JC">
+            <persName>SERVANTS.ANTONY.1_JC</persName>
+          </person>
+          <person xml:id="SERVANTS.OCTAVIUS.1_JC">
+            <persName>SERVANTS.OCTAVIUS.1_JC</persName>
+          </person>
+          <person xml:id="PLEBEIANS_JC">
+            <persName>First, Second, Third, and Fourth Plebeians</persName>
+          </person>
+          <person xml:id="PLEBEIANS.0.1_JC">
+            <persName>PLEBEIANS.0.1_JC</persName>
+          </person>
+          <person xml:id="PLEBEIANS.0.2_JC">
+            <persName>PLEBEIANS.0.2_JC</persName>
+          </person>
+          <person xml:id="PLEBEIANS.0.3_JC">
+            <persName>PLEBEIANS.0.3_JC</persName>
+          </person>
+          <person xml:id="PLEBEIANS.0.4_JC">
+            <persName>PLEBEIANS.0.4_JC</persName>
+          </person>
+          <person xml:id="CinnaPoet_JC">
+            <persName>Cinna</persName>
+          </person>
+          <person xml:id="Octavius_JC">
+            <persName>Octavius</persName>
+          </person>
+          <person xml:id="Lepidus_JC">
+            <persName>Lepidus</persName>
+          </person>
+          <person xml:id="SOLDIERS.BRUTUS.Lucilius_JC">
+            <persName>Lucilius</persName>
+          </person>
+          <person xml:id="Pindarus_JC">
+            <persName>Pindarus</persName>
+          </person>
+          <person xml:id="SOLDIERS.BRUTUS.0.1_JC">
+            <persName>SOLDIERS.BRUTUS.0.1_JC</persName>
+          </person>
+          <person xml:id="SOLDIERS.BRUTUS.0.2_JC">
+            <persName>SOLDIERS.BRUTUS.0.2_JC</persName>
+          </person>
+          <person xml:id="SOLDIERS.BRUTUS.0.3_JC">
+            <persName>SOLDIERS.BRUTUS.0.3_JC</persName>
+          </person>
+          <person xml:id="Poet_JC">
+            <persName>Poet_JC</persName>
+          </person>
+          <person xml:id="SOLDIERS.BRUTUS.Messala_JC">
+            <persName>Messala</persName>
+          </person>
+          <person xml:id="SOLDIERS.BRUTUS.Titinius_JC">
+            <persName>Titinius</persName>
+          </person>
+          <person xml:id="SOLDIERS.BRUTUS.Varro_JC">
+            <persName>Varro</persName>
+          </person>
+          <person xml:id="SOLDIERS.BRUTUS.Claudius_JC">
+            <persName>Claudius</persName>
+          </person>
+          <person xml:id="Messenger_JC">
+            <persName>Messenger_JC</persName>
+          </person>
+          <person xml:id="SOLDIERS.BRUTUS.Cato_JC">
+            <persName>Young Cato</persName>
+          </person>
+          <person xml:id="SOLDIERS.ANTONY.0.1_JC">
+            <persName>SOLDIERS.ANTONY.0.1_JC</persName>
+          </person>
+          <person xml:id="SOLDIERS.ANTONY.0.2_JC">
+            <persName>SOLDIERS.ANTONY.0.2_JC</persName>
+          </person>
+          <person xml:id="SOLDIERS.BRUTUS.Clitus_JC">
+            <persName>Clitus</persName>
+          </person>
+          <person xml:id="SOLDIERS.BRUTUS.Dardanus_JC">
+            <persName>Dardanus</persName>
+          </person>
+          <person xml:id="SOLDIERS.BRUTUS.Volumnius_JC">
+            <persName>Volumnius</persName>
+          </person>
+          <person xml:id="SOLDIERS.BRUTUS.Strato_JC">
+            <persName>Strato</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/julius-caesar.xml
+++ b/tei/julius-caesar.xml
@@ -88,157 +88,157 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Flavius_JC">
+          <person xml:id="Flavius_JC" sex="MALE">
             <persName>Flavius</persName>
           </person>
-          <person xml:id="COMMONERS.Carpenter_JC">
+          <person xml:id="COMMONERS.Carpenter_JC" sex="MALE">
             <persName>COMMONERS.Carpenter_JC</persName>
           </person>
-          <person xml:id="Marullus_JC">
+          <person xml:id="Marullus_JC" sex="MALE">
             <persName>Marullus</persName>
           </person>
-          <person xml:id="COMMONERS.Cobbler_JC">
+          <person xml:id="COMMONERS.Cobbler_JC" sex="MALE">
             <persName>COMMONERS.Cobbler_JC</persName>
           </person>
-          <person xml:id="Caesar_JC">
+          <person xml:id="Caesar_JC" ana="http://www.wikidata.org/entity/Q1048">
             <persName>Julius Caesar</persName>
           </person>
-          <person xml:id="Casca_JC">
+          <person xml:id="Casca_JC" sex="MALE">
             <persName>Casca</persName>
           </person>
-          <person xml:id="Calphurnia_JC">
+          <person xml:id="Calphurnia_JC" sex="FEMALE">
             <persName>Calphurnia</persName>
           </person>
-          <person xml:id="Antony_JC">
+          <person xml:id="Antony_JC" ana="http://www.wikidata.org/entity/Q51673">
             <persName>Mark Antony</persName>
           </person>
-          <person xml:id="Soothsayer_JC">
+          <person xml:id="Soothsayer_JC" sex="MALE">
             <persName>Soothsayer_JC</persName>
           </person>
-          <person xml:id="Brutus_JC">
+          <person xml:id="Brutus_JC" ana="http://www.wikidata.org/entity/Q172248">
             <persName>Marcus Brutus</persName>
           </person>
-          <person xml:id="Cassius_JC">
+          <person xml:id="Cassius_JC" ana="http://www.wikidata.org/entity/Q207370">
             <persName>Caius Cassius</persName>
           </person>
-          <person xml:id="Cicero_JC">
+          <person xml:id="Cicero_JC" sex="MALE">
             <persName>Cicero</persName>
           </person>
-          <person xml:id="Cinna_JC">
+          <person xml:id="Cinna_JC" sex="MALE">
             <persName>Cinna</persName>
           </person>
-          <person xml:id="Lucius_JC">
+          <person xml:id="Lucius_JC" sex="MALE">
             <persName>Lucius</persName>
           </person>
-          <person xml:id="Decius_JC">
+          <person xml:id="Decius_JC" sex="MALE">
             <persName>Decius Brutus</persName>
           </person>
-          <person xml:id="Metellus_JC">
+          <person xml:id="Metellus_JC" sex="MALE">
             <persName>Metellus Cimber</persName>
           </person>
-          <person xml:id="Trebonius_JC">
+          <person xml:id="Trebonius_JC" sex="MALE">
             <persName>Trebonius</persName>
           </person>
-          <person xml:id="Portia_JC">
+          <person xml:id="Portia_JC" sex="FEMALE">
             <persName>Portia</persName>
           </person>
-          <person xml:id="Ligarius_JC">
+          <person xml:id="Ligarius_JC" sex="MALE">
             <persName>Caius Ligarius</persName>
           </person>
-          <person xml:id="SERVANTS.CAESAR.1_JC">
+          <person xml:id="SERVANTS.CAESAR.1_JC" sex="MALE">
             <persName>SERVANTS.CAESAR.1_JC</persName>
           </person>
-          <person xml:id="Publius_JC">
+          <person xml:id="Publius_JC" ana="http://www.wikidata.org/entity/Q214765">
             <persName>Publius</persName>
           </person>
-          <person xml:id="Artemidorus_JC">
+          <person xml:id="Artemidorus_JC" sex="MALE">
             <persName>Artemidorus</persName>
           </person>
-          <person xml:id="Popilius_JC">
+          <person xml:id="Popilius_JC" ana="http://www.wikidata.org/entity/Q464897">
             <persName>Popilius Lena</persName>
           </person>
-          <person xml:id="SERVANTS.ANTONY.1_JC">
+          <person xml:id="SERVANTS.ANTONY.1_JC" sex="MALE">
             <persName>SERVANTS.ANTONY.1_JC</persName>
           </person>
-          <person xml:id="SERVANTS.OCTAVIUS.1_JC">
+          <person xml:id="SERVANTS.OCTAVIUS.1_JC" sex="MALE">
             <persName>SERVANTS.OCTAVIUS.1_JC</persName>
           </person>
-          <person xml:id="PLEBEIANS_JC">
-            <persName>First, Second, Third, and Fourth Plebeians</persName>
-          </person>
-          <person xml:id="PLEBEIANS.0.1_JC">
+          <personGrp xml:id="PLEBEIANS_JC" sex="UNKNOWN">
+            <name>First, Second, Third, and Fourth Plebeians</name>
+          </personGrp>
+          <person xml:id="PLEBEIANS.0.1_JC" sex="MALE">
             <persName>PLEBEIANS.0.1_JC</persName>
           </person>
-          <person xml:id="PLEBEIANS.0.2_JC">
+          <person xml:id="PLEBEIANS.0.2_JC" sex="MALE">
             <persName>PLEBEIANS.0.2_JC</persName>
           </person>
-          <person xml:id="PLEBEIANS.0.3_JC">
+          <person xml:id="PLEBEIANS.0.3_JC" sex="MALE">
             <persName>PLEBEIANS.0.3_JC</persName>
           </person>
-          <person xml:id="PLEBEIANS.0.4_JC">
+          <person xml:id="PLEBEIANS.0.4_JC" sex="MALE">
             <persName>PLEBEIANS.0.4_JC</persName>
           </person>
-          <person xml:id="CinnaPoet_JC">
+          <person xml:id="CinnaPoet_JC" sex="MALE">
             <persName>Cinna</persName>
           </person>
-          <person xml:id="Octavius_JC">
+          <person xml:id="Octavius_JC" ana="http://www.wikidata.org/entity/Q363084">
             <persName>Octavius</persName>
           </person>
-          <person xml:id="Lepidus_JC">
+          <person xml:id="Lepidus_JC" sex="MALE">
             <persName>Lepidus</persName>
           </person>
-          <person xml:id="SOLDIERS.BRUTUS.Lucilius_JC">
+          <person xml:id="SOLDIERS.BRUTUS.Lucilius_JC" sex="MALE">
             <persName>Lucilius</persName>
           </person>
-          <person xml:id="Pindarus_JC">
+          <person xml:id="Pindarus_JC" sex="MALE">
             <persName>Pindarus</persName>
           </person>
-          <person xml:id="SOLDIERS.BRUTUS.0.1_JC">
+          <person xml:id="SOLDIERS.BRUTUS.0.1_JC" sex="MALE">
             <persName>SOLDIERS.BRUTUS.0.1_JC</persName>
           </person>
-          <person xml:id="SOLDIERS.BRUTUS.0.2_JC">
+          <person xml:id="SOLDIERS.BRUTUS.0.2_JC" sex="MALE">
             <persName>SOLDIERS.BRUTUS.0.2_JC</persName>
           </person>
-          <person xml:id="SOLDIERS.BRUTUS.0.3_JC">
+          <person xml:id="SOLDIERS.BRUTUS.0.3_JC" sex="MALE">
             <persName>SOLDIERS.BRUTUS.0.3_JC</persName>
           </person>
-          <person xml:id="Poet_JC">
+          <person xml:id="Poet_JC" sex="MALE">
             <persName>Poet_JC</persName>
           </person>
-          <person xml:id="SOLDIERS.BRUTUS.Messala_JC">
+          <person xml:id="SOLDIERS.BRUTUS.Messala_JC" sex="MALE">
             <persName>Messala</persName>
           </person>
-          <person xml:id="SOLDIERS.BRUTUS.Titinius_JC">
+          <person xml:id="SOLDIERS.BRUTUS.Titinius_JC" sex="MALE">
             <persName>Titinius</persName>
           </person>
-          <person xml:id="SOLDIERS.BRUTUS.Varro_JC">
+          <person xml:id="SOLDIERS.BRUTUS.Varro_JC" sex="MALE">
             <persName>Varro</persName>
           </person>
-          <person xml:id="SOLDIERS.BRUTUS.Claudius_JC">
+          <person xml:id="SOLDIERS.BRUTUS.Claudius_JC" ana="http://www.wikidata.org/entity/Q1411">
             <persName>Claudius</persName>
           </person>
-          <person xml:id="Messenger_JC">
+          <person xml:id="Messenger_JC" sex="MALE">
             <persName>Messenger_JC</persName>
           </person>
-          <person xml:id="SOLDIERS.BRUTUS.Cato_JC">
+          <person xml:id="SOLDIERS.BRUTUS.Cato_JC" sex="MALE">
             <persName>Young Cato</persName>
           </person>
-          <person xml:id="SOLDIERS.ANTONY.0.1_JC">
-            <persName>SOLDIERS.ANTONY.0.1_JC</persName>
-          </person>
-          <person xml:id="SOLDIERS.ANTONY.0.2_JC">
-            <persName>SOLDIERS.ANTONY.0.2_JC</persName>
-          </person>
-          <person xml:id="SOLDIERS.BRUTUS.Clitus_JC">
+          <personGrp xml:id="SOLDIERS.ANTONY.0.1_JC" sex="UNKNOWN">
+            <name>SOLDIERS.ANTONY.0.1_JC</name>
+          </personGrp>
+          <personGrp xml:id="SOLDIERS.ANTONY.0.2_JC" sex="UNKNOWN">
+            <name>SOLDIERS.ANTONY.0.2_JC</name>
+          </personGrp>
+          <person xml:id="SOLDIERS.BRUTUS.Clitus_JC" sex="MALE">
             <persName>Clitus</persName>
           </person>
-          <person xml:id="SOLDIERS.BRUTUS.Dardanus_JC">
+          <person xml:id="SOLDIERS.BRUTUS.Dardanus_JC" sex="MALE">
             <persName>Dardanus</persName>
           </person>
-          <person xml:id="SOLDIERS.BRUTUS.Volumnius_JC">
+          <person xml:id="SOLDIERS.BRUTUS.Volumnius_JC" sex="MALE">
             <persName>Volumnius</persName>
           </person>
-          <person xml:id="SOLDIERS.BRUTUS.Strato_JC">
+          <person xml:id="SOLDIERS.BRUTUS.Strato_JC" sex="MALE">
             <persName>Strato</persName>
           </person>
         </listPerson>

--- a/tei/king-john.xml
+++ b/tei/king-john.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,97 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="KingJohn_Jn"><persName>John</persName></person><person xml:id="Chatillion_Jn"><persName>Chatillion</persName></person><person xml:id="QueenEleanor_Jn"><persName>Queen Eleanor</persName></person><person xml:id="Essex_Jn"><persName>Earl of Essex</persName></person><person xml:id="Bastard_Jn"><persName>Bastard Philip Faulconbridge</persName><persName>Bastard Philip Faulconbridge</persName></person><person xml:id="RobertFaulconbridge_Jn"><persName>Robert Faulconbridge</persName></person><person xml:id="LadyFaulconbridge_Jn"><persName>Lady Faulconbridge</persName></person><person xml:id="Gurney_Jn"><persName>James Gurney</persName></person><person xml:id="Dauphin_Jn"><persName>Louis the Dauphin</persName></person><person xml:id="Arthur_Jn"><persName>Arthur</persName></person><person xml:id="Austria_Jn"><persName>Duke of Austria Limoges</persName><persName>Duke of Austria Limoges</persName></person><person xml:id="Constance_Jn"><persName>Constance</persName></person><person xml:id="KingPhilip_Jn"><persName>King Philip II</persName></person><person xml:id="Blanche_Jn"><persName>Blanche</persName></person><person xml:id="CITIZENS.0.1_Jn"><persName>Citizen</persName></person><person xml:id="HERALDS.FRENCH_Jn"><persName>French Herald</persName></person><person xml:id="HERALDS.ENGLISH_Jn"><persName>English Herald</persName></person><person xml:id="Salisbury_Jn"><persName>Earl of Salisbury</persName></person><person xml:id="Pandulph_Jn"><persName>Cardinal Pandulph</persName></person><person xml:id="Hubert_Jn"><persName>Hubert</persName></person><person xml:id="EXECUTIONERS.0.1_Jn"><persName>EXECUTIONERS.0.1_Jn</persName></person><person xml:id="Pembroke_Jn"><persName>Earl of Pembroke</persName></person><person xml:id="MESSENGERS.ENGLISH.1_Jn"><persName>English Messenger, French Messenger, Sheriff, Lords, Soldiers, Attendants</persName></person><person xml:id="Peter_Jn"><persName>Peter</persName></person><person xml:id="Bigot_Jn"><persName>Lord Bigot</persName></person><person xml:id="Melun_Jn"><persName>Count Melun</persName></person><person xml:id="MESSENGERS.FRENCH.1_Jn"><persName>English Messenger, French Messenger, Sheriff, Lords, Soldiers, Attendants</persName></person><person xml:id="PrinceHenry_Jn"><persName>Prince Henry</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="KingJohn_Jn">
+            <persName>John</persName>
+          </person>
+          <person xml:id="Chatillion_Jn">
+            <persName>Chatillion</persName>
+          </person>
+          <person xml:id="QueenEleanor_Jn">
+            <persName>Queen Eleanor</persName>
+          </person>
+          <person xml:id="Essex_Jn">
+            <persName>Earl of Essex</persName>
+          </person>
+          <person xml:id="Bastard_Jn">
+            <persName>Bastard Philip Faulconbridge</persName>
+            <persName>Bastard Philip Faulconbridge</persName>
+          </person>
+          <person xml:id="RobertFaulconbridge_Jn">
+            <persName>Robert Faulconbridge</persName>
+          </person>
+          <person xml:id="LadyFaulconbridge_Jn">
+            <persName>Lady Faulconbridge</persName>
+          </person>
+          <person xml:id="Gurney_Jn">
+            <persName>James Gurney</persName>
+          </person>
+          <person xml:id="Dauphin_Jn">
+            <persName>Louis the Dauphin</persName>
+          </person>
+          <person xml:id="Arthur_Jn">
+            <persName>Arthur</persName>
+          </person>
+          <person xml:id="Austria_Jn">
+            <persName>Duke of Austria Limoges</persName>
+            <persName>Duke of Austria Limoges</persName>
+          </person>
+          <person xml:id="Constance_Jn">
+            <persName>Constance</persName>
+          </person>
+          <person xml:id="KingPhilip_Jn">
+            <persName>King Philip II</persName>
+          </person>
+          <person xml:id="Blanche_Jn">
+            <persName>Blanche</persName>
+          </person>
+          <person xml:id="CITIZENS.0.1_Jn">
+            <persName>Citizen</persName>
+          </person>
+          <person xml:id="HERALDS.FRENCH_Jn">
+            <persName>French Herald</persName>
+          </person>
+          <person xml:id="HERALDS.ENGLISH_Jn">
+            <persName>English Herald</persName>
+          </person>
+          <person xml:id="Salisbury_Jn">
+            <persName>Earl of Salisbury</persName>
+          </person>
+          <person xml:id="Pandulph_Jn">
+            <persName>Cardinal Pandulph</persName>
+          </person>
+          <person xml:id="Hubert_Jn">
+            <persName>Hubert</persName>
+          </person>
+          <person xml:id="EXECUTIONERS.0.1_Jn">
+            <persName>EXECUTIONERS.0.1_Jn</persName>
+          </person>
+          <person xml:id="Pembroke_Jn">
+            <persName>Earl of Pembroke</persName>
+          </person>
+          <person xml:id="MESSENGERS.ENGLISH.1_Jn">
+            <persName>English Messenger, French Messenger, Sheriff, Lords, Soldiers, Attendants</persName>
+          </person>
+          <person xml:id="Peter_Jn">
+            <persName>Peter</persName>
+          </person>
+          <person xml:id="Bigot_Jn">
+            <persName>Lord Bigot</persName>
+          </person>
+          <person xml:id="Melun_Jn">
+            <persName>Count Melun</persName>
+          </person>
+          <person xml:id="MESSENGERS.FRENCH.1_Jn">
+            <persName>English Messenger, French Messenger, Sheriff, Lords, Soldiers, Attendants</persName>
+          </person>
+          <person xml:id="PrinceHenry_Jn">
+            <persName>Prince Henry</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/king-john.xml
+++ b/tei/king-john.xml
@@ -88,90 +88,90 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="KingJohn_Jn">
+          <person xml:id="KingJohn_Jn" ana="http://www.wikidata.org/entity/Q129308">
             <persName>John</persName>
           </person>
-          <person xml:id="Chatillion_Jn">
+          <person xml:id="Chatillion_Jn" sex="MALE">
             <persName>Chatillion</persName>
           </person>
-          <person xml:id="QueenEleanor_Jn">
+          <person xml:id="QueenEleanor_Jn" ana="http://www.wikidata.org/entity/Q178525">
             <persName>Queen Eleanor</persName>
           </person>
-          <person xml:id="Essex_Jn">
+          <person xml:id="Essex_Jn" ana="http://www.wikidata.org/entity/Q5534602">
             <persName>Earl of Essex</persName>
           </person>
-          <person xml:id="Bastard_Jn">
+          <person xml:id="Bastard_Jn" ana="http://www.wikidata.org/entity/Q1405919">
             <persName>Bastard Philip Faulconbridge</persName>
             <persName>Bastard Philip Faulconbridge</persName>
           </person>
-          <person xml:id="RobertFaulconbridge_Jn">
+          <person xml:id="RobertFaulconbridge_Jn" ana="http://www.wikidata.org/entity/Q3438706">
             <persName>Robert Faulconbridge</persName>
           </person>
-          <person xml:id="LadyFaulconbridge_Jn">
+          <person xml:id="LadyFaulconbridge_Jn" sex="FEMALE">
             <persName>Lady Faulconbridge</persName>
           </person>
-          <person xml:id="Gurney_Jn">
+          <person xml:id="Gurney_Jn" sex="MALE">
             <persName>James Gurney</persName>
           </person>
-          <person xml:id="Dauphin_Jn">
+          <person xml:id="Dauphin_Jn" sex="MALE">
             <persName>Louis the Dauphin</persName>
           </person>
-          <person xml:id="Arthur_Jn">
+          <person xml:id="Arthur_Jn" ana="http://www.wikidata.org/entity/Q45792">
             <persName>Arthur</persName>
           </person>
-          <person xml:id="Austria_Jn">
+          <person xml:id="Austria_Jn" sex="MALE">
             <persName>Duke of Austria Limoges</persName>
             <persName>Duke of Austria Limoges</persName>
           </person>
-          <person xml:id="Constance_Jn">
+          <person xml:id="Constance_Jn" ana="http://www.wikidata.org/entity/Q234317">
             <persName>Constance</persName>
           </person>
-          <person xml:id="KingPhilip_Jn">
+          <person xml:id="KingPhilip_Jn" ana="http://www.wikidata.org/entity/Q34428">
             <persName>King Philip II</persName>
           </person>
-          <person xml:id="Blanche_Jn">
+          <person xml:id="Blanche_Jn" ana="http://www.wikidata.org/entity/Q353">
             <persName>Blanche</persName>
           </person>
-          <person xml:id="CITIZENS.0.1_Jn">
+          <person xml:id="CITIZENS.0.1_Jn" sex="UNKNOWN">
             <persName>Citizen</persName>
           </person>
-          <person xml:id="HERALDS.FRENCH_Jn">
+          <person xml:id="HERALDS.FRENCH_Jn" sex="MALE">
             <persName>French Herald</persName>
           </person>
-          <person xml:id="HERALDS.ENGLISH_Jn">
+          <person xml:id="HERALDS.ENGLISH_Jn" sex="MALE">
             <persName>English Herald</persName>
           </person>
-          <person xml:id="Salisbury_Jn">
+          <person xml:id="Salisbury_Jn" sex="MALE">
             <persName>Earl of Salisbury</persName>
           </person>
-          <person xml:id="Pandulph_Jn">
+          <person xml:id="Pandulph_Jn" sex="MALE">
             <persName>Cardinal Pandulph</persName>
           </person>
-          <person xml:id="Hubert_Jn">
+          <person xml:id="Hubert_Jn" ana="http://www.wikidata.org/entity/Q1381324">
             <persName>Hubert</persName>
           </person>
-          <person xml:id="EXECUTIONERS.0.1_Jn">
-            <persName>EXECUTIONERS.0.1_Jn</persName>
-          </person>
-          <person xml:id="Pembroke_Jn">
+          <personGrp xml:id="EXECUTIONERS.0.1_Jn" sex="UNKNOWN">
+            <name>EXECUTIONERS.0.1_Jn</name>
+          </personGrp>
+          <person xml:id="Pembroke_Jn" ana="http://www.wikidata.org/entity/Q348911">
             <persName>Earl of Pembroke</persName>
           </person>
-          <person xml:id="MESSENGERS.ENGLISH.1_Jn">
-            <persName>English Messenger, French Messenger, Sheriff, Lords, Soldiers, Attendants</persName>
-          </person>
-          <person xml:id="Peter_Jn">
+          <personGrp xml:id="MESSENGERS.ENGLISH.1_Jn" sex="UNKNOWN">
+            <name>English Messenger, French Messenger, Sheriff, Lords, Soldiers, Attendants</name>
+          </personGrp>
+          <person xml:id="Peter_Jn" sex="MALE">
             <persName>Peter</persName>
           </person>
-          <person xml:id="Bigot_Jn">
+          <person xml:id="Bigot_Jn" ana="http://www.wikidata.org/entity/Q3438706">
             <persName>Lord Bigot</persName>
           </person>
-          <person xml:id="Melun_Jn">
+          <person xml:id="Melun_Jn" sex="MALE">
             <persName>Count Melun</persName>
           </person>
-          <person xml:id="MESSENGERS.FRENCH.1_Jn">
-            <persName>English Messenger, French Messenger, Sheriff, Lords, Soldiers, Attendants</persName>
-          </person>
-          <person xml:id="PrinceHenry_Jn">
+          <personGrp xml:id="MESSENGERS.FRENCH.1_Jn" sex="UNKNOWN">
+            <name>English Messenger, French Messenger, Sheriff, Lords, Soldiers, Attendants</name>
+          </personGrp>
+          <person xml:id="PrinceHenry_Jn" ana="http://www.wikidata.org/entity/Q160311">
             <persName>Prince Henry</persName>
           </person>
         </listPerson>

--- a/tei/king-lear.xml
+++ b/tei/king-lear.xml
@@ -88,105 +88,105 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Kent_Lr">
+          <person xml:id="Kent_Lr" sex="MALE">
             <persName>Earl of Kent</persName>
           </person>
-          <person xml:id="Gloucester_Lr">
+          <person xml:id="Gloucester_Lr" sex="MALE">
             <persName>Earl of Gloucester</persName>
           </person>
-          <person xml:id="Edmund_Lr">
+          <person xml:id="Edmund_Lr" sex="MALE">
             <persName>Edmund</persName>
           </person>
-          <person xml:id="Lear_Lr">
+          <person xml:id="Lear_Lr" ana="http://www.wikidata.org/entity/Q1800394">
             <persName>Lear</persName>
           </person>
-          <person xml:id="Goneril_Lr">
+          <person xml:id="Goneril_Lr" sex="FEMALE">
             <persName>Goneril</persName>
           </person>
-          <person xml:id="Cordelia_Lr">
+          <person xml:id="Cordelia_Lr" sex="FEMALE">
             <persName>Cordelia</persName>
           </person>
-          <person xml:id="Regan_Lr">
+          <person xml:id="Regan_Lr" sex="FEMALE">
             <persName>Regan</persName>
           </person>
-          <person xml:id="Albany_Lr">
+          <person xml:id="Albany_Lr" sex="MALE">
             <persName>Duke of Albany</persName>
           </person>
-          <person xml:id="Cornwall_Lr">
+          <person xml:id="Cornwall_Lr" sex="MALE">
             <persName>Duke of Cornwall</persName>
           </person>
-          <person xml:id="Burgundy_Lr">
+          <person xml:id="Burgundy_Lr" sex="MALE">
             <persName>Duke of Burgundy</persName>
           </person>
-          <person xml:id="France_Lr">
+          <person xml:id="France_Lr" sex="MALE">
             <persName>King of France</persName>
           </person>
-          <person xml:id="Edgar_Lr">
+          <person xml:id="Edgar_Lr" sex="MALE">
             <persName>Edgar</persName>
           </person>
-          <person xml:id="Oswald_Lr">
+          <person xml:id="Oswald_Lr" sex="MALE">
             <persName>Oswald</persName>
           </person>
-          <person xml:id="ATTENDANTS.LEAR.0.3_Lr">
-            <persName>Knights in Lear’s train, Servants, Officers, Soldiers, Attendants, Gentlemen</persName>
-          </person>
-          <person xml:id="Fool_Lr">
+          <personGrp xml:id="ATTENDANTS.LEAR.0.3_Lr" sex="UNKNOWN">
+            <name>Knights in Lear’s train, Servants, Officers, Soldiers, Attendants, Gentlemen</name>
+          </personGrp>
+          <person xml:id="Fool_Lr" sex="MALE">
             <persName>Fool</persName>
           </person>
-          <person xml:id="ATTENDANTS.X.1_Lr">
-            <persName>ATTENDANTS.X.1_Lr</persName>
-          </person>
-          <person xml:id="Curan_Lr">
+          <personGrp xml:id="ATTENDANTS.X.1_Lr" sex="UNKNOWN">
+            <name>ATTENDANTS.X.1_Lr</name>
+          </personGrp>
+          <person xml:id="Curan_Lr" sex="MALE">
             <persName>Curan</persName>
           </person>
-          <person xml:id="ATTENDANTS.X.2_Lr">
-            <persName>ATTENDANTS.X.2_Lr</persName>
-          </person>
-          <person xml:id="ATTENDANTS.X.3_Lr">
-            <persName>ATTENDANTS.X.3_Lr</persName>
-          </person>
-          <person xml:id="SERVANTS.0.1_Lr">
+          <personGrp xml:id="ATTENDANTS.X.2_Lr" sex="UNKNOWN">
+            <name>ATTENDANTS.X.2_Lr</name>
+          </personGrp>
+          <personGrp xml:id="ATTENDANTS.X.3_Lr" sex="UNKNOWN">
+            <name>ATTENDANTS.X.3_Lr</name>
+          </personGrp>
+          <person xml:id="SERVANTS.0.1_Lr" sex="MALE">
             <persName>SERVANTS.0.1_Lr</persName>
           </person>
-          <person xml:id="SERVANTS.0.2_Lr">
+          <person xml:id="SERVANTS.0.2_Lr" sex="MALE">
             <persName>SERVANTS.0.2_Lr</persName>
           </person>
-          <person xml:id="SERVANTS.0.3_Lr">
+          <person xml:id="SERVANTS.0.3_Lr" sex="MALE">
             <persName>SERVANTS.0.3_Lr</persName>
           </person>
-          <person xml:id="OldMan_Lr">
+          <person xml:id="OldMan_Lr" sex="MALE">
             <persName>Old Man</persName>
           </person>
-          <person xml:id="MESSENGERS.X.1_Lr">
-            <persName>MESSENGERS.X.1_Lr</persName>
-          </person>
-          <person xml:id="ATTENDANTS.X.4_Lr">
-            <persName>ATTENDANTS.X.4_Lr</persName>
-          </person>
-          <person xml:id="Doctor_Lr">
+          <personGrp xml:id="MESSENGERS.X.1_Lr" sex="UNKNOWN">
+            <name>MESSENGERS.X.1_Lr</name>
+          </personGrp>
+          <personGrp xml:id="ATTENDANTS.X.4_Lr" sex="UNKNOWN">
+            <name>ATTENDANTS.X.4_Lr</name>
+          </personGrp>
+          <person xml:id="Doctor_Lr" sex="MALE">
             <persName>Doctor</persName>
           </person>
-          <person xml:id="MESSENGERS.X.2_Lr">
-            <persName>MESSENGERS.X.2_Lr</persName>
-          </person>
-          <person xml:id="ATTENDANTS.CORDELIA.1_Lr">
-            <persName>Knights in Lear’s train, Servants, Officers, Soldiers, Attendants, Gentlemen</persName>
-          </person>
-          <person xml:id="SOLDIERS.CAPTAINS.1_Lr">
-            <persName>SOLDIERS.CAPTAINS.1_Lr</persName>
-          </person>
-          <person xml:id="SOLDIERS.CAPTAINS.2_Lr">
-            <persName>SOLDIERS.CAPTAINS.2_Lr</persName>
-          </person>
-          <person xml:id="Herald_Lr">
+          <personGrp xml:id="MESSENGERS.X.2_Lr" sex="UNKNOWN">
+            <name>MESSENGERS.X.2_Lr</name>
+          </personGrp>
+          <personGrp xml:id="ATTENDANTS.CORDELIA.1_Lr" sex="UNKNOWN">
+            <name>Knights in Lear’s train, Servants, Officers, Soldiers, Attendants, Gentlemen</name>
+          </personGrp>
+          <personGrp xml:id="SOLDIERS.CAPTAINS.1_Lr" sex="UNKNOWN">
+            <name>SOLDIERS.CAPTAINS.1_Lr</name>
+          </personGrp>
+          <personGrp xml:id="SOLDIERS.CAPTAINS.2_Lr" sex="UNKNOWN">
+            <name>SOLDIERS.CAPTAINS.2_Lr</name>
+          </personGrp>
+          <person xml:id="Herald_Lr" sex="MALE">
             <persName>Herald</persName>
           </person>
-          <person xml:id="ATTENDANTS.ALBANY_Lr">
-            <persName>Knights in Lear’s train, Servants, Officers, Soldiers, Attendants, Gentlemen</persName>
-          </person>
-          <person xml:id="MESSENGERS.X.3_Lr">
-            <persName>MESSENGERS.X.3_Lr</persName>
-          </person>
+          <personGrp xml:id="ATTENDANTS.ALBANY_Lr" sex="UNKNOWN">
+            <name>Knights in Lear’s train, Servants, Officers, Soldiers, Attendants, Gentlemen</name>
+          </personGrp>
+          <personGrp xml:id="MESSENGERS.X.3_Lr" sex="UNKNOWN">
+            <name>MESSENGERS.X.3_Lr</name>
+          </personGrp>
         </listPerson>
       </particDesc>
     </profileDesc>

--- a/tei/king-lear.xml
+++ b/tei/king-lear.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,110 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Kent_Lr"><persName>Earl of Kent</persName></person><person xml:id="Gloucester_Lr"><persName>Earl of Gloucester</persName></person><person xml:id="Edmund_Lr"><persName>Edmund</persName></person><person xml:id="Lear_Lr"><persName>Lear</persName></person><person xml:id="Goneril_Lr"><persName>Goneril</persName></person><person xml:id="Cordelia_Lr"><persName>Cordelia</persName></person><person xml:id="Regan_Lr"><persName>Regan</persName></person><person xml:id="Albany_Lr"><persName>Duke of Albany</persName></person><person xml:id="Cornwall_Lr"><persName>Duke of Cornwall</persName></person><person xml:id="Burgundy_Lr"><persName>Duke of Burgundy</persName></person><person xml:id="France_Lr"><persName>King of France</persName></person><person xml:id="Edgar_Lr"><persName>Edgar</persName></person><person xml:id="Oswald_Lr"><persName>Oswald</persName></person><person xml:id="ATTENDANTS.LEAR.0.3_Lr"><persName>Knights in Lear’s train, Servants, Officers, Soldiers, Attendants, Gentlemen</persName></person><person xml:id="Fool_Lr"><persName>Fool</persName></person><person xml:id="ATTENDANTS.X.1_Lr"><persName>ATTENDANTS.X.1_Lr</persName></person><person xml:id="Curan_Lr"><persName>Curan</persName></person><person xml:id="ATTENDANTS.X.2_Lr"><persName>ATTENDANTS.X.2_Lr</persName></person><person xml:id="ATTENDANTS.X.3_Lr"><persName>ATTENDANTS.X.3_Lr</persName></person><person xml:id="SERVANTS.0.1_Lr"><persName>SERVANTS.0.1_Lr</persName></person><person xml:id="SERVANTS.0.2_Lr"><persName>SERVANTS.0.2_Lr</persName></person><person xml:id="SERVANTS.0.3_Lr"><persName>SERVANTS.0.3_Lr</persName></person><person xml:id="OldMan_Lr"><persName>Old Man</persName></person><person xml:id="MESSENGERS.X.1_Lr"><persName>MESSENGERS.X.1_Lr</persName></person><person xml:id="ATTENDANTS.X.4_Lr"><persName>ATTENDANTS.X.4_Lr</persName></person><person xml:id="Doctor_Lr"><persName>Doctor</persName></person><person xml:id="MESSENGERS.X.2_Lr"><persName>MESSENGERS.X.2_Lr</persName></person><person xml:id="ATTENDANTS.CORDELIA.1_Lr"><persName>Knights in Lear’s train, Servants, Officers, Soldiers, Attendants, Gentlemen</persName></person><person xml:id="SOLDIERS.CAPTAINS.1_Lr"><persName>SOLDIERS.CAPTAINS.1_Lr</persName></person><person xml:id="SOLDIERS.CAPTAINS.2_Lr"><persName>SOLDIERS.CAPTAINS.2_Lr</persName></person><person xml:id="Herald_Lr"><persName>Herald</persName></person><person xml:id="ATTENDANTS.ALBANY_Lr"><persName>Knights in Lear’s train, Servants, Officers, Soldiers, Attendants, Gentlemen</persName></person><person xml:id="MESSENGERS.X.3_Lr"><persName>MESSENGERS.X.3_Lr</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Kent_Lr">
+            <persName>Earl of Kent</persName>
+          </person>
+          <person xml:id="Gloucester_Lr">
+            <persName>Earl of Gloucester</persName>
+          </person>
+          <person xml:id="Edmund_Lr">
+            <persName>Edmund</persName>
+          </person>
+          <person xml:id="Lear_Lr">
+            <persName>Lear</persName>
+          </person>
+          <person xml:id="Goneril_Lr">
+            <persName>Goneril</persName>
+          </person>
+          <person xml:id="Cordelia_Lr">
+            <persName>Cordelia</persName>
+          </person>
+          <person xml:id="Regan_Lr">
+            <persName>Regan</persName>
+          </person>
+          <person xml:id="Albany_Lr">
+            <persName>Duke of Albany</persName>
+          </person>
+          <person xml:id="Cornwall_Lr">
+            <persName>Duke of Cornwall</persName>
+          </person>
+          <person xml:id="Burgundy_Lr">
+            <persName>Duke of Burgundy</persName>
+          </person>
+          <person xml:id="France_Lr">
+            <persName>King of France</persName>
+          </person>
+          <person xml:id="Edgar_Lr">
+            <persName>Edgar</persName>
+          </person>
+          <person xml:id="Oswald_Lr">
+            <persName>Oswald</persName>
+          </person>
+          <person xml:id="ATTENDANTS.LEAR.0.3_Lr">
+            <persName>Knights in Lear’s train, Servants, Officers, Soldiers, Attendants, Gentlemen</persName>
+          </person>
+          <person xml:id="Fool_Lr">
+            <persName>Fool</persName>
+          </person>
+          <person xml:id="ATTENDANTS.X.1_Lr">
+            <persName>ATTENDANTS.X.1_Lr</persName>
+          </person>
+          <person xml:id="Curan_Lr">
+            <persName>Curan</persName>
+          </person>
+          <person xml:id="ATTENDANTS.X.2_Lr">
+            <persName>ATTENDANTS.X.2_Lr</persName>
+          </person>
+          <person xml:id="ATTENDANTS.X.3_Lr">
+            <persName>ATTENDANTS.X.3_Lr</persName>
+          </person>
+          <person xml:id="SERVANTS.0.1_Lr">
+            <persName>SERVANTS.0.1_Lr</persName>
+          </person>
+          <person xml:id="SERVANTS.0.2_Lr">
+            <persName>SERVANTS.0.2_Lr</persName>
+          </person>
+          <person xml:id="SERVANTS.0.3_Lr">
+            <persName>SERVANTS.0.3_Lr</persName>
+          </person>
+          <person xml:id="OldMan_Lr">
+            <persName>Old Man</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.1_Lr">
+            <persName>MESSENGERS.X.1_Lr</persName>
+          </person>
+          <person xml:id="ATTENDANTS.X.4_Lr">
+            <persName>ATTENDANTS.X.4_Lr</persName>
+          </person>
+          <person xml:id="Doctor_Lr">
+            <persName>Doctor</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.2_Lr">
+            <persName>MESSENGERS.X.2_Lr</persName>
+          </person>
+          <person xml:id="ATTENDANTS.CORDELIA.1_Lr">
+            <persName>Knights in Lear’s train, Servants, Officers, Soldiers, Attendants, Gentlemen</persName>
+          </person>
+          <person xml:id="SOLDIERS.CAPTAINS.1_Lr">
+            <persName>SOLDIERS.CAPTAINS.1_Lr</persName>
+          </person>
+          <person xml:id="SOLDIERS.CAPTAINS.2_Lr">
+            <persName>SOLDIERS.CAPTAINS.2_Lr</persName>
+          </person>
+          <person xml:id="Herald_Lr">
+            <persName>Herald</persName>
+          </person>
+          <person xml:id="ATTENDANTS.ALBANY_Lr">
+            <persName>Knights in Lear’s train, Servants, Officers, Soldiers, Attendants, Gentlemen</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.3_Lr">
+            <persName>MESSENGERS.X.3_Lr</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/love-s-labor-s-lost.xml
+++ b/tei/love-s-labor-s-lost.xml
@@ -88,78 +88,78 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="King_LLL">
+          <person xml:id="King_LLL" sex="MALE">
             <persName>King</persName>
           </person>
-          <person xml:id="Longaville_LLL">
+          <person xml:id="Longaville_LLL" sex="MALE">
             <persName>Longaville</persName>
           </person>
-          <person xml:id="Dumaine_LLL">
+          <person xml:id="Dumaine_LLL" sex="MALE">
             <persName>Dumaine</persName>
           </person>
-          <person xml:id="Berowne_LLL">
+          <person xml:id="Berowne_LLL" sex="MALE">
             <persName>Berowne</persName>
           </person>
-          <person xml:id="Dull_LLL">
+          <person xml:id="Dull_LLL" sex="MALE">
             <persName>Dull Constable</persName>
             <persName>Dull Constable</persName>
           </person>
-          <person xml:id="Costard_LLL">
+          <person xml:id="Costard_LLL" sex="MALE">
             <persName>Costard Clown Swain</persName>
             <persName>Costard Clown Swain</persName>
             <persName>Costard Clown Swain</persName>
           </person>
-          <person xml:id="Armado_LLL">
+          <person xml:id="Armado_LLL" sex="MALE">
             <persName>Armado Braggart</persName>
             <persName>Armado Braggart</persName>
           </person>
-          <person xml:id="Boy_LLL">
+          <person xml:id="Boy_LLL" sex="MALE">
             <persName>Boy Page Mote</persName>
             <persName>Boy Page Mote</persName>
             <persName>Boy Page Mote</persName>
           </person>
-          <person xml:id="Jaquenetta_LLL">
+          <person xml:id="Jaquenetta_LLL" sex="FEMALE">
             <persName>Jaquenetta Wench</persName>
             <persName>Jaquenetta Wench</persName>
           </person>
-          <person xml:id="Boyet_LLL">
+          <person xml:id="Boyet_LLL" sex="MALE">
             <persName>Boyet</persName>
           </person>
-          <person xml:id="Princess_LLL">
+          <person xml:id="Princess_LLL" sex="FEMALE">
             <persName>Princess</persName>
           </person>
-          <person xml:id="LORDS.0_LLL">
-            <persName>Lords, Blackamoors, Musicians</persName>
-          </person>
-          <person xml:id="Maria_LLL">
+          <personGrp xml:id="LORDS.0_LLL" sex="UNKNOWN">
+            <name>Lords, Blackamoors, Musicians</name>
+          </personGrp>
+          <person xml:id="Maria_LLL" sex="FEMALE">
             <persName>Maria</persName>
           </person>
-          <person xml:id="Katherine_LLL">
+          <person xml:id="Katherine_LLL" sex="FEMALE">
             <persName>Katherine</persName>
           </person>
-          <person xml:id="Rosaline_LLL">
+          <person xml:id="Rosaline_LLL" sex="FEMALE">
             <persName>Rosaline</persName>
           </person>
-          <person xml:id="Forester_LLL">
+          <person xml:id="Forester_LLL" sex="MALE">
             <persName>Forester</persName>
           </person>
-          <person xml:id="Nathaniel_LLL">
+          <person xml:id="Nathaniel_LLL" sex="MALE">
             <persName>Nathaniel Curate</persName>
             <persName>Nathaniel Curate</persName>
           </person>
-          <person xml:id="Holofernes_LLL">
+          <person xml:id="Holofernes_LLL" sex="MALE">
             <persName>Holofernes Pedant</persName>
             <persName>Holofernes Pedant</persName>
           </person>
-          <person xml:id="Marcade_LLL">
+          <person xml:id="Marcade_LLL" sex="MALE">
             <persName>Monsieur Marcade</persName>
           </person>
-          <person xml:id="Spring_LLL">
-            <persName>Lords, Blackamoors, Musicians</persName>
-          </person>
-          <person xml:id="Winter_LLL">
-            <persName>Lords, Blackamoors, Musicians</persName>
-          </person>
+          <personGrp xml:id="Spring_LLL" sex="UNKNOWN">
+            <name>Lords, Blackamoors, Musicians</name>
+          </personGrp>
+          <personGrp xml:id="Winter_LLL" sex="UNKNOWN">
+            <name>Lords, Blackamoors, Musicians</name>
+          </personGrp>
         </listPerson>
       </particDesc>
     </profileDesc>

--- a/tei/love-s-labor-s-lost.xml
+++ b/tei/love-s-labor-s-lost.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,83 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="King_LLL"><persName>King</persName></person><person xml:id="Longaville_LLL"><persName>Longaville</persName></person><person xml:id="Dumaine_LLL"><persName>Dumaine</persName></person><person xml:id="Berowne_LLL"><persName>Berowne</persName></person><person xml:id="Dull_LLL"><persName>Dull Constable</persName><persName>Dull Constable</persName></person><person xml:id="Costard_LLL"><persName>Costard Clown Swain</persName><persName>Costard Clown Swain</persName><persName>Costard Clown Swain</persName></person><person xml:id="Armado_LLL"><persName>Armado Braggart</persName><persName>Armado Braggart</persName></person><person xml:id="Boy_LLL"><persName>Boy Page Mote</persName><persName>Boy Page Mote</persName><persName>Boy Page Mote</persName></person><person xml:id="Jaquenetta_LLL"><persName>Jaquenetta Wench</persName><persName>Jaquenetta Wench</persName></person><person xml:id="Boyet_LLL"><persName>Boyet</persName></person><person xml:id="Princess_LLL"><persName>Princess</persName></person><person xml:id="LORDS.0_LLL"><persName>Lords, Blackamoors, Musicians</persName></person><person xml:id="Maria_LLL"><persName>Maria</persName></person><person xml:id="Katherine_LLL"><persName>Katherine</persName></person><person xml:id="Rosaline_LLL"><persName>Rosaline</persName></person><person xml:id="Forester_LLL"><persName>Forester</persName></person><person xml:id="Nathaniel_LLL"><persName>Nathaniel Curate</persName><persName>Nathaniel Curate</persName></person><person xml:id="Holofernes_LLL"><persName>Holofernes Pedant</persName><persName>Holofernes Pedant</persName></person><person xml:id="Marcade_LLL"><persName>Monsieur Marcade</persName></person><person xml:id="Spring_LLL"><persName>Lords, Blackamoors, Musicians</persName></person><person xml:id="Winter_LLL"><persName>Lords, Blackamoors, Musicians</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="King_LLL">
+            <persName>King</persName>
+          </person>
+          <person xml:id="Longaville_LLL">
+            <persName>Longaville</persName>
+          </person>
+          <person xml:id="Dumaine_LLL">
+            <persName>Dumaine</persName>
+          </person>
+          <person xml:id="Berowne_LLL">
+            <persName>Berowne</persName>
+          </person>
+          <person xml:id="Dull_LLL">
+            <persName>Dull Constable</persName>
+            <persName>Dull Constable</persName>
+          </person>
+          <person xml:id="Costard_LLL">
+            <persName>Costard Clown Swain</persName>
+            <persName>Costard Clown Swain</persName>
+            <persName>Costard Clown Swain</persName>
+          </person>
+          <person xml:id="Armado_LLL">
+            <persName>Armado Braggart</persName>
+            <persName>Armado Braggart</persName>
+          </person>
+          <person xml:id="Boy_LLL">
+            <persName>Boy Page Mote</persName>
+            <persName>Boy Page Mote</persName>
+            <persName>Boy Page Mote</persName>
+          </person>
+          <person xml:id="Jaquenetta_LLL">
+            <persName>Jaquenetta Wench</persName>
+            <persName>Jaquenetta Wench</persName>
+          </person>
+          <person xml:id="Boyet_LLL">
+            <persName>Boyet</persName>
+          </person>
+          <person xml:id="Princess_LLL">
+            <persName>Princess</persName>
+          </person>
+          <person xml:id="LORDS.0_LLL">
+            <persName>Lords, Blackamoors, Musicians</persName>
+          </person>
+          <person xml:id="Maria_LLL">
+            <persName>Maria</persName>
+          </person>
+          <person xml:id="Katherine_LLL">
+            <persName>Katherine</persName>
+          </person>
+          <person xml:id="Rosaline_LLL">
+            <persName>Rosaline</persName>
+          </person>
+          <person xml:id="Forester_LLL">
+            <persName>Forester</persName>
+          </person>
+          <person xml:id="Nathaniel_LLL">
+            <persName>Nathaniel Curate</persName>
+            <persName>Nathaniel Curate</persName>
+          </person>
+          <person xml:id="Holofernes_LLL">
+            <persName>Holofernes Pedant</persName>
+            <persName>Holofernes Pedant</persName>
+          </person>
+          <person xml:id="Marcade_LLL">
+            <persName>Monsieur Marcade</persName>
+          </person>
+          <person xml:id="Spring_LLL">
+            <persName>Lords, Blackamoors, Musicians</persName>
+          </person>
+          <person xml:id="Winter_LLL">
+            <persName>Lords, Blackamoors, Musicians</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/macbeth.xml
+++ b/tei/macbeth.xml
@@ -88,141 +88,141 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="WITCHES.1_Mac">
-            <persName>WITCHES.1_Mac</persName>
-          </person>
-          <person xml:id="WITCHES.2_Mac">
-            <persName>WITCHES.2_Mac</persName>
-          </person>
-          <person xml:id="WITCHES.3_Mac">
-            <persName>WITCHES.3_Mac</persName>
-          </person>
-          <person xml:id="Duncan_Mac">
+          <personGrp xml:id="WITCHES.1_Mac" sex="UNKNOWN">
+            <name>WITCHES.1_Mac</name>
+          </personGrp>
+          <personGrp xml:id="WITCHES.2_Mac" sex="UNKNOWN">
+            <name>WITCHES.2_Mac</name>
+          </personGrp>
+          <personGrp xml:id="WITCHES.3_Mac" sex="UNKNOWN">
+            <name>WITCHES.3_Mac</name>
+          </personGrp>
+          <person xml:id="Duncan_Mac" ana="http://www.wikidata.org/entity/Q26326">
             <persName>Duncan</persName>
           </person>
-          <person xml:id="Malcolm_Mac">
+          <person xml:id="Malcolm_Mac" ana="http://www.wikidata.org/entity/Q68508">
             <persName>Malcolm</persName>
           </person>
-          <person xml:id="SOLDIERS.Captain_Mac">
-            <persName>SOLDIERS.Captain_Mac</persName>
-          </person>
-          <person xml:id="Lennox_Mac">
+          <personGrp xml:id="SOLDIERS.Captain_Mac" sex="UNKNOWN">
+            <name>SOLDIERS.Captain_Mac</name>
+          </personGrp>
+          <person xml:id="Lennox_Mac" sex="MALE">
             <persName>Lennox</persName>
           </person>
-          <person xml:id="Ross_Mac">
+          <person xml:id="Ross_Mac" sex="MALE">
             <persName>Ross</persName>
           </person>
-          <person xml:id="Macbeth_Mac">
+          <person xml:id="Macbeth_Mac" ana="http://www.wikidata.org/entity/Q244403">
             <persName>Macbeth</persName>
           </person>
-          <person xml:id="Banquo_Mac">
+          <person xml:id="Banquo_Mac" sex="MALE">
             <persName>Banquo</persName>
           </person>
-          <person xml:id="Angus_Mac">
+          <person xml:id="Angus_Mac" sex="MALE">
             <persName>Angus</persName>
           </person>
-          <person xml:id="LadyMacbeth_Mac">
+          <person xml:id="LadyMacbeth_Mac" ana="http://www.wikidata.org/entity/Q272390">
             <persName>Lady Macbeth</persName>
           </person>
-          <person xml:id="MESSENGERS.1_Mac">
-            <persName>Three Messengers, Three Servants, a Lord, a Soldier</persName>
-          </person>
-          <person xml:id="Fleance_Mac">
+          <personGrp xml:id="MESSENGERS.1_Mac" sex="UNKNOWN">
+            <name>Three Messengers, Three Servants, a Lord, a Soldier</name>
+          </personGrp>
+          <person xml:id="Fleance_Mac" sex="MALE">
             <persName>Fleance</persName>
           </person>
-          <person xml:id="Porter_Mac">
+          <person xml:id="Porter_Mac" sex="MALE">
             <persName>Porter_Mac</persName>
           </person>
-          <person xml:id="Macduff_Mac">
+          <person xml:id="Macduff_Mac" sex="MALE">
             <persName>Macduff</persName>
           </person>
-          <person xml:id="Donalbain_Mac">
+          <person xml:id="Donalbain_Mac" ana="http://www.wikidata.org/entity/Q356602">
             <persName>Donalbain</persName>
           </person>
-          <person xml:id="OldMan_Mac">
+          <person xml:id="OldMan_Mac" sex="MALE">
             <persName>OldMan_Mac</persName>
           </person>
-          <person xml:id="SERVANTS.X.2_Mac">
-            <persName>Three Messengers, Three Servants, a Lord, a Soldier</persName>
-          </person>
-          <person xml:id="MURDERERS.1_Mac">
-            <persName>MURDERERS.1_Mac</persName>
-          </person>
-          <person xml:id="MURDERERS.2_Mac">
-            <persName>MURDERERS.2_Mac</persName>
-          </person>
-          <person xml:id="SERVANTS.X.3_Mac">
-            <persName>Three Messengers, Three Servants, a Lord, a Soldier</persName>
-          </person>
-          <person xml:id="MURDERERS.3_Mac">
-            <persName>MURDERERS.3_Mac</persName>
-          </person>
-          <person xml:id="ATTENDANTS_Mac">
-            <persName>Attendants, a Sewer, Servants, Lords, Thanes, Soldiers (all nonspeaking)</persName>
-          </person>
-          <person xml:id="Hecate_Mac">
+          <personGrp xml:id="SERVANTS.X.2_Mac" sex="UNKNOWN">
+            <name>Three Messengers, Three Servants, a Lord, a Soldier</name>
+          </personGrp>
+          <personGrp xml:id="MURDERERS.1_Mac" sex="UNKNOWN">
+            <name>MURDERERS.1_Mac</name>
+          </personGrp>
+          <personGrp xml:id="MURDERERS.2_Mac" sex="UNKNOWN">
+            <name>MURDERERS.2_Mac</name>
+          </personGrp>
+          <personGrp xml:id="SERVANTS.X.3_Mac" sex="UNKNOWN">
+            <name>Three Messengers, Three Servants, a Lord, a Soldier</name>
+          </personGrp>
+          <personGrp xml:id="MURDERERS.3_Mac" sex="UNKNOWN">
+            <name>MURDERERS.3_Mac</name>
+          </personGrp>
+          <personGrp xml:id="ATTENDANTS_Mac" sex="UNKNOWN">
+            <name>Attendants, a Sewer, Servants, Lords, Thanes, Soldiers (all nonspeaking)</name>
+          </personGrp>
+          <person xml:id="Hecate_Mac" sex="FEMALE">
             <persName>Hecate</persName>
           </person>
-          <person xml:id="Lord_Mac">
-            <persName>Three Messengers, Three Servants, a Lord, a Soldier</persName>
-          </person>
-          <person xml:id="SPIRITS.1_Mac">
-            <persName>SPIRITS.1_Mac</persName>
-          </person>
-          <person xml:id="SPIRITS.2_Mac">
-            <persName>SPIRITS.2_Mac</persName>
-          </person>
-          <person xml:id="SPIRITS.3_Mac">
-            <persName>SPIRITS.3_Mac</persName>
-          </person>
-          <person xml:id="LadyMacduff_Mac">
+          <personGrp xml:id="Lord_Mac" sex="UNKNOWN">
+            <name>Three Messengers, Three Servants, a Lord, a Soldier</name>
+          </personGrp>
+          <personGrp xml:id="SPIRITS.1_Mac" sex="UNKNOWN">
+            <name>SPIRITS.1_Mac</name>
+          </personGrp>
+          <personGrp xml:id="SPIRITS.2_Mac" sex="UNKNOWN">
+            <name>SPIRITS.2_Mac</name>
+          </personGrp>
+          <personGrp xml:id="SPIRITS.3_Mac" sex="UNKNOWN">
+            <name>SPIRITS.3_Mac</name>
+          </personGrp>
+          <person xml:id="LadyMacduff_Mac" sex="FEMALE">
             <persName>Lady Macduff</persName>
           </person>
-          <person xml:id="MacduffsSon_Mac">
+          <person xml:id="MacduffsSon_Mac" sex="MALE">
             <persName>MacduffsSon_Mac</persName>
           </person>
-          <person xml:id="MESSENGERS.2_Mac">
-            <persName>Three Messengers, Three Servants, a Lord, a Soldier</persName>
-          </person>
-          <person xml:id="MURDERERS.0.1_Mac">
-            <persName>MURDERERS.0.1_Mac</persName>
-          </person>
-          <person xml:id="Doctor1_Mac">
+          <personGrp xml:id="MESSENGERS.2_Mac" sex="UNKNOWN">
+            <name>Three Messengers, Three Servants, a Lord, a Soldier</name>
+          </personGrp>
+          <personGrp xml:id="MURDERERS.0.1_Mac" sex="UNKNOWN">
+            <name>MURDERERS.0.1_Mac</name>
+          </personGrp>
+          <person xml:id="Doctor1_Mac" sex="MALE">
             <persName>Doctor1_Mac</persName>
           </person>
-          <person xml:id="Doctor2_Mac">
+          <person sex="" xml:id="Doctor2_Mac">
             <persName>both attending upon Lady Macbeth</persName>
           </person>
-          <person xml:id="Gentlewoman_Mac">
+          <person sex="" xml:id="Gentlewoman_Mac">
             <persName>both attending upon Lady Macbeth</persName>
           </person>
-          <person xml:id="Menteith_Mac">
+          <person xml:id="Menteith_Mac" sex="MALE">
             <persName>Menteith</persName>
           </person>
-          <person xml:id="Caithness_Mac">
+          <person xml:id="Caithness_Mac" sex="MALE">
             <persName>Caithness</persName>
           </person>
-          <person xml:id="SERVANTS.X.4_Mac">
-            <persName>Three Messengers, Three Servants, a Lord, a Soldier</persName>
-          </person>
-          <person xml:id="Seyton_Mac">
+          <personGrp xml:id="SERVANTS.X.4_Mac" sex="UNKNOWN">
+            <name>Three Messengers, Three Servants, a Lord, a Soldier</name>
+          </personGrp>
+          <person xml:id="Seyton_Mac" sex="MALE">
             <persName>Seyton</persName>
           </person>
-          <person xml:id="Siward_Mac">
+          <person xml:id="Siward_Mac" ana="http://www.wikidata.org/entity/Q68366">
             <persName>Siward</persName>
           </person>
-          <person xml:id="SOLDIERS.MALCOLM.0.1_Mac">
-            <persName>Three Messengers, Three Servants, a Lord, a Soldier</persName>
-          </person>
-          <person xml:id="MESSENGERS.3_Mac">
-            <persName>Three Messengers, Three Servants, a Lord, a Soldier</persName>
-          </person>
-          <person xml:id="YoungSiward_Mac">
+          <personGrp xml:id="SOLDIERS.MALCOLM.0.1_Mac" sex="UNKNOWN">
+            <name>Three Messengers, Three Servants, a Lord, a Soldier</name>
+          </personGrp>
+          <personGrp xml:id="MESSENGERS.3_Mac" sex="UNKNOWN">
+            <name>Three Messengers, Three Servants, a Lord, a Soldier</name>
+          </personGrp>
+          <person xml:id="YoungSiward_Mac" ana="http://www.wikidata.org/entity/Q68366">
             <persName>Young Siward</persName>
           </person>
-          <person xml:id="SOLDIERS.MALCOLM_Mac">
-            <persName>Attendants, a Sewer, Servants, Lords, Thanes, Soldiers (all nonspeaking)</persName>
-          </person>
+          <personGrp xml:id="SOLDIERS.MALCOLM_Mac" sex="UNKNOWN">
+            <name>Attendants, a Sewer, Servants, Lords, Thanes, Soldiers (all nonspeaking)</name>
+          </personGrp>
         </listPerson>
       </particDesc>
     </profileDesc>

--- a/tei/macbeth.xml
+++ b/tei/macbeth.xml
@@ -190,10 +190,10 @@
           <person xml:id="Doctor1_Mac" sex="MALE">
             <persName>Doctor1_Mac</persName>
           </person>
-          <person sex="" xml:id="Doctor2_Mac">
+          <person xml:id="Doctor2_Mac">
             <persName>both attending upon Lady Macbeth</persName>
           </person>
-          <person sex="" xml:id="Gentlewoman_Mac">
+          <person xml:id="Gentlewoman_Mac">
             <persName>both attending upon Lady Macbeth</persName>
           </person>
           <person xml:id="Menteith_Mac" sex="MALE">

--- a/tei/macbeth.xml
+++ b/tei/macbeth.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,146 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="WITCHES.1_Mac"><persName>WITCHES.1_Mac</persName></person><person xml:id="WITCHES.2_Mac"><persName>WITCHES.2_Mac</persName></person><person xml:id="WITCHES.3_Mac"><persName>WITCHES.3_Mac</persName></person><person xml:id="Duncan_Mac"><persName>Duncan</persName></person><person xml:id="Malcolm_Mac"><persName>Malcolm</persName></person><person xml:id="SOLDIERS.Captain_Mac"><persName>SOLDIERS.Captain_Mac</persName></person><person xml:id="Lennox_Mac"><persName>Lennox</persName></person><person xml:id="Ross_Mac"><persName>Ross</persName></person><person xml:id="Macbeth_Mac"><persName>Macbeth</persName></person><person xml:id="Banquo_Mac"><persName>Banquo</persName></person><person xml:id="Angus_Mac"><persName>Angus</persName></person><person xml:id="LadyMacbeth_Mac"><persName>Lady Macbeth</persName></person><person xml:id="MESSENGERS.1_Mac"><persName>Three Messengers, Three Servants, a Lord, a Soldier</persName></person><person xml:id="Fleance_Mac"><persName>Fleance</persName></person><person xml:id="Porter_Mac"><persName>Porter_Mac</persName></person><person xml:id="Macduff_Mac"><persName>Macduff</persName></person><person xml:id="Donalbain_Mac"><persName>Donalbain</persName></person><person xml:id="OldMan_Mac"><persName>OldMan_Mac</persName></person><person xml:id="SERVANTS.X.2_Mac"><persName>Three Messengers, Three Servants, a Lord, a Soldier</persName></person><person xml:id="MURDERERS.1_Mac"><persName>MURDERERS.1_Mac</persName></person><person xml:id="MURDERERS.2_Mac"><persName>MURDERERS.2_Mac</persName></person><person xml:id="SERVANTS.X.3_Mac"><persName>Three Messengers, Three Servants, a Lord, a Soldier</persName></person><person xml:id="MURDERERS.3_Mac"><persName>MURDERERS.3_Mac</persName></person><person xml:id="ATTENDANTS_Mac"><persName>Attendants, a Sewer, Servants, Lords, Thanes, Soldiers (all nonspeaking)</persName></person><person xml:id="Hecate_Mac"><persName>Hecate</persName></person><person xml:id="Lord_Mac"><persName>Three Messengers, Three Servants, a Lord, a Soldier</persName></person><person xml:id="SPIRITS.1_Mac"><persName>SPIRITS.1_Mac</persName></person><person xml:id="SPIRITS.2_Mac"><persName>SPIRITS.2_Mac</persName></person><person xml:id="SPIRITS.3_Mac"><persName>SPIRITS.3_Mac</persName></person><person xml:id="LadyMacduff_Mac"><persName>Lady Macduff</persName></person><person xml:id="MacduffsSon_Mac"><persName>MacduffsSon_Mac</persName></person><person xml:id="MESSENGERS.2_Mac"><persName>Three Messengers, Three Servants, a Lord, a Soldier</persName></person><person xml:id="MURDERERS.0.1_Mac"><persName>MURDERERS.0.1_Mac</persName></person><person xml:id="Doctor1_Mac"><persName>Doctor1_Mac</persName></person><person xml:id="Doctor2_Mac"><persName>both attending upon Lady Macbeth</persName></person><person xml:id="Gentlewoman_Mac"><persName>both attending upon Lady Macbeth</persName></person><person xml:id="Menteith_Mac"><persName>Menteith</persName></person><person xml:id="Caithness_Mac"><persName>Caithness</persName></person><person xml:id="SERVANTS.X.4_Mac"><persName>Three Messengers, Three Servants, a Lord, a Soldier</persName></person><person xml:id="Seyton_Mac"><persName>Seyton</persName></person><person xml:id="Siward_Mac"><persName>Siward</persName></person><person xml:id="SOLDIERS.MALCOLM.0.1_Mac"><persName>Three Messengers, Three Servants, a Lord, a Soldier</persName></person><person xml:id="MESSENGERS.3_Mac"><persName>Three Messengers, Three Servants, a Lord, a Soldier</persName></person><person xml:id="YoungSiward_Mac"><persName>Young Siward</persName></person><person xml:id="SOLDIERS.MALCOLM_Mac"><persName>Attendants, a Sewer, Servants, Lords, Thanes, Soldiers (all nonspeaking)</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="WITCHES.1_Mac">
+            <persName>WITCHES.1_Mac</persName>
+          </person>
+          <person xml:id="WITCHES.2_Mac">
+            <persName>WITCHES.2_Mac</persName>
+          </person>
+          <person xml:id="WITCHES.3_Mac">
+            <persName>WITCHES.3_Mac</persName>
+          </person>
+          <person xml:id="Duncan_Mac">
+            <persName>Duncan</persName>
+          </person>
+          <person xml:id="Malcolm_Mac">
+            <persName>Malcolm</persName>
+          </person>
+          <person xml:id="SOLDIERS.Captain_Mac">
+            <persName>SOLDIERS.Captain_Mac</persName>
+          </person>
+          <person xml:id="Lennox_Mac">
+            <persName>Lennox</persName>
+          </person>
+          <person xml:id="Ross_Mac">
+            <persName>Ross</persName>
+          </person>
+          <person xml:id="Macbeth_Mac">
+            <persName>Macbeth</persName>
+          </person>
+          <person xml:id="Banquo_Mac">
+            <persName>Banquo</persName>
+          </person>
+          <person xml:id="Angus_Mac">
+            <persName>Angus</persName>
+          </person>
+          <person xml:id="LadyMacbeth_Mac">
+            <persName>Lady Macbeth</persName>
+          </person>
+          <person xml:id="MESSENGERS.1_Mac">
+            <persName>Three Messengers, Three Servants, a Lord, a Soldier</persName>
+          </person>
+          <person xml:id="Fleance_Mac">
+            <persName>Fleance</persName>
+          </person>
+          <person xml:id="Porter_Mac">
+            <persName>Porter_Mac</persName>
+          </person>
+          <person xml:id="Macduff_Mac">
+            <persName>Macduff</persName>
+          </person>
+          <person xml:id="Donalbain_Mac">
+            <persName>Donalbain</persName>
+          </person>
+          <person xml:id="OldMan_Mac">
+            <persName>OldMan_Mac</persName>
+          </person>
+          <person xml:id="SERVANTS.X.2_Mac">
+            <persName>Three Messengers, Three Servants, a Lord, a Soldier</persName>
+          </person>
+          <person xml:id="MURDERERS.1_Mac">
+            <persName>MURDERERS.1_Mac</persName>
+          </person>
+          <person xml:id="MURDERERS.2_Mac">
+            <persName>MURDERERS.2_Mac</persName>
+          </person>
+          <person xml:id="SERVANTS.X.3_Mac">
+            <persName>Three Messengers, Three Servants, a Lord, a Soldier</persName>
+          </person>
+          <person xml:id="MURDERERS.3_Mac">
+            <persName>MURDERERS.3_Mac</persName>
+          </person>
+          <person xml:id="ATTENDANTS_Mac">
+            <persName>Attendants, a Sewer, Servants, Lords, Thanes, Soldiers (all nonspeaking)</persName>
+          </person>
+          <person xml:id="Hecate_Mac">
+            <persName>Hecate</persName>
+          </person>
+          <person xml:id="Lord_Mac">
+            <persName>Three Messengers, Three Servants, a Lord, a Soldier</persName>
+          </person>
+          <person xml:id="SPIRITS.1_Mac">
+            <persName>SPIRITS.1_Mac</persName>
+          </person>
+          <person xml:id="SPIRITS.2_Mac">
+            <persName>SPIRITS.2_Mac</persName>
+          </person>
+          <person xml:id="SPIRITS.3_Mac">
+            <persName>SPIRITS.3_Mac</persName>
+          </person>
+          <person xml:id="LadyMacduff_Mac">
+            <persName>Lady Macduff</persName>
+          </person>
+          <person xml:id="MacduffsSon_Mac">
+            <persName>MacduffsSon_Mac</persName>
+          </person>
+          <person xml:id="MESSENGERS.2_Mac">
+            <persName>Three Messengers, Three Servants, a Lord, a Soldier</persName>
+          </person>
+          <person xml:id="MURDERERS.0.1_Mac">
+            <persName>MURDERERS.0.1_Mac</persName>
+          </person>
+          <person xml:id="Doctor1_Mac">
+            <persName>Doctor1_Mac</persName>
+          </person>
+          <person xml:id="Doctor2_Mac">
+            <persName>both attending upon Lady Macbeth</persName>
+          </person>
+          <person xml:id="Gentlewoman_Mac">
+            <persName>both attending upon Lady Macbeth</persName>
+          </person>
+          <person xml:id="Menteith_Mac">
+            <persName>Menteith</persName>
+          </person>
+          <person xml:id="Caithness_Mac">
+            <persName>Caithness</persName>
+          </person>
+          <person xml:id="SERVANTS.X.4_Mac">
+            <persName>Three Messengers, Three Servants, a Lord, a Soldier</persName>
+          </person>
+          <person xml:id="Seyton_Mac">
+            <persName>Seyton</persName>
+          </person>
+          <person xml:id="Siward_Mac">
+            <persName>Siward</persName>
+          </person>
+          <person xml:id="SOLDIERS.MALCOLM.0.1_Mac">
+            <persName>Three Messengers, Three Servants, a Lord, a Soldier</persName>
+          </person>
+          <person xml:id="MESSENGERS.3_Mac">
+            <persName>Three Messengers, Three Servants, a Lord, a Soldier</persName>
+          </person>
+          <person xml:id="YoungSiward_Mac">
+            <persName>Young Siward</persName>
+          </person>
+          <person xml:id="SOLDIERS.MALCOLM_Mac">
+            <persName>Attendants, a Sewer, Servants, Lords, Thanes, Soldiers (all nonspeaking)</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/measure-for-measure.xml
+++ b/tei/measure-for-measure.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,83 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Duke_MM"><persName>Duke</persName></person><person xml:id="Escalus_MM"><persName>Escalus</persName></person><person xml:id="Angelo_MM"><persName>Angelo</persName></person><person xml:id="Lucio_MM"><persName>Lucio</persName></person><person xml:id="GENTLEMEN.1_MM"><persName>GENTLEMEN.1_MM</persName></person><person xml:id="GENTLEMEN.2_MM"><persName>GENTLEMEN.2_MM</persName></person><person xml:id="Bawd_MM"><persName>Mistress Overdone</persName></person><person xml:id="Pompey_MM"><persName>Pompey</persName></person><person xml:id="Claudio_MM"><persName>Claudio</persName></person><person xml:id="Provost_MM"><persName>Provost</persName></person><person xml:id="FriarThomas_MM"><persName>Friar Thomas</persName></person><person xml:id="Isabella_MM"><persName>Isabella</persName></person><person xml:id="Nun_MM"><persName>Francisca</persName></person><person xml:id="Elbow_MM"><persName>Elbow</persName></person><person xml:id="Froth_MM"><persName>Froth</persName></person><person xml:id="Justice_MM"><persName>Justice</persName></person><person xml:id="SERVANTS.1_MM"><persName>Servant</persName></person><person xml:id="Juliet_MM"><persName>Juliet</persName></person><person xml:id="Boy_MM"><persName>Boy</persName></person><person xml:id="Mariana_MM"><persName>Mariana</persName></person><person xml:id="Abhorson_MM"><persName>Abhorson</persName></person><person xml:id="Messenger_MM"><persName>Messenger</persName></person><person xml:id="Barnardine_MM"><persName>Barnardine</persName></person><person xml:id="FriarPeter_MM"><persName>Friar Peter</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Duke_MM">
+            <persName>Duke</persName>
+          </person>
+          <person xml:id="Escalus_MM">
+            <persName>Escalus</persName>
+          </person>
+          <person xml:id="Angelo_MM">
+            <persName>Angelo</persName>
+          </person>
+          <person xml:id="Lucio_MM">
+            <persName>Lucio</persName>
+          </person>
+          <person xml:id="GENTLEMEN.1_MM">
+            <persName>GENTLEMEN.1_MM</persName>
+          </person>
+          <person xml:id="GENTLEMEN.2_MM">
+            <persName>GENTLEMEN.2_MM</persName>
+          </person>
+          <person xml:id="Bawd_MM">
+            <persName>Mistress Overdone</persName>
+          </person>
+          <person xml:id="Pompey_MM">
+            <persName>Pompey</persName>
+          </person>
+          <person xml:id="Claudio_MM">
+            <persName>Claudio</persName>
+          </person>
+          <person xml:id="Provost_MM">
+            <persName>Provost</persName>
+          </person>
+          <person xml:id="FriarThomas_MM">
+            <persName>Friar Thomas</persName>
+          </person>
+          <person xml:id="Isabella_MM">
+            <persName>Isabella</persName>
+          </person>
+          <person xml:id="Nun_MM">
+            <persName>Francisca</persName>
+          </person>
+          <person xml:id="Elbow_MM">
+            <persName>Elbow</persName>
+          </person>
+          <person xml:id="Froth_MM">
+            <persName>Froth</persName>
+          </person>
+          <person xml:id="Justice_MM">
+            <persName>Justice</persName>
+          </person>
+          <person xml:id="SERVANTS.1_MM">
+            <persName>Servant</persName>
+          </person>
+          <person xml:id="Juliet_MM">
+            <persName>Juliet</persName>
+          </person>
+          <person xml:id="Boy_MM">
+            <persName>Boy</persName>
+          </person>
+          <person xml:id="Mariana_MM">
+            <persName>Mariana</persName>
+          </person>
+          <person xml:id="Abhorson_MM">
+            <persName>Abhorson</persName>
+          </person>
+          <person xml:id="Messenger_MM">
+            <persName>Messenger</persName>
+          </person>
+          <person xml:id="Barnardine_MM">
+            <persName>Barnardine</persName>
+          </person>
+          <person xml:id="FriarPeter_MM">
+            <persName>Friar Peter</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/measure-for-measure.xml
+++ b/tei/measure-for-measure.xml
@@ -88,76 +88,76 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Duke_MM">
+          <person xml:id="Duke_MM" sex="MALE">
             <persName>Duke</persName>
           </person>
-          <person xml:id="Escalus_MM">
+          <person xml:id="Escalus_MM" sex="MALE">
             <persName>Escalus</persName>
           </person>
-          <person xml:id="Angelo_MM">
+          <person xml:id="Angelo_MM" sex="MALE">
             <persName>Angelo</persName>
           </person>
-          <person xml:id="Lucio_MM">
+          <person xml:id="Lucio_MM" sex="MALE">
             <persName>Lucio</persName>
           </person>
-          <person xml:id="GENTLEMEN.1_MM">
+          <person xml:id="GENTLEMEN.1_MM" sex="MALE">
             <persName>GENTLEMEN.1_MM</persName>
           </person>
-          <person xml:id="GENTLEMEN.2_MM">
+          <person xml:id="GENTLEMEN.2_MM" sex="MALE">
             <persName>GENTLEMEN.2_MM</persName>
           </person>
-          <person xml:id="Bawd_MM">
+          <person xml:id="Bawd_MM" sex="FEMALE">
             <persName>Mistress Overdone</persName>
           </person>
-          <person xml:id="Pompey_MM">
+          <person xml:id="Pompey_MM" sex="MALE">
             <persName>Pompey</persName>
           </person>
-          <person xml:id="Claudio_MM">
+          <person xml:id="Claudio_MM" sex="MALE">
             <persName>Claudio</persName>
           </person>
-          <person xml:id="Provost_MM">
+          <person xml:id="Provost_MM" sex="MALE">
             <persName>Provost</persName>
           </person>
-          <person xml:id="FriarThomas_MM">
+          <person xml:id="FriarThomas_MM" sex="MALE">
             <persName>Friar Thomas</persName>
           </person>
-          <person xml:id="Isabella_MM">
+          <person xml:id="Isabella_MM" sex="FEMALE">
             <persName>Isabella</persName>
           </person>
-          <person xml:id="Nun_MM">
+          <person xml:id="Nun_MM" sex="FEMALE">
             <persName>Francisca</persName>
           </person>
-          <person xml:id="Elbow_MM">
+          <person xml:id="Elbow_MM" sex="MALE">
             <persName>Elbow</persName>
           </person>
-          <person xml:id="Froth_MM">
+          <person xml:id="Froth_MM" sex="MALE">
             <persName>Froth</persName>
           </person>
-          <person xml:id="Justice_MM">
+          <person xml:id="Justice_MM" sex="MALE">
             <persName>Justice</persName>
           </person>
-          <person xml:id="SERVANTS.1_MM">
+          <person xml:id="SERVANTS.1_MM" sex="UNKNOWN">
             <persName>Servant</persName>
           </person>
-          <person xml:id="Juliet_MM">
+          <person xml:id="Juliet_MM" sex="FEMALE">
             <persName>Juliet</persName>
           </person>
-          <person xml:id="Boy_MM">
+          <person xml:id="Boy_MM" sex="MALE">
             <persName>Boy</persName>
           </person>
-          <person xml:id="Mariana_MM">
+          <person xml:id="Mariana_MM" sex="FEMALE">
             <persName>Mariana</persName>
           </person>
-          <person xml:id="Abhorson_MM">
+          <person xml:id="Abhorson_MM" sex="MALE">
             <persName>Abhorson</persName>
           </person>
-          <person xml:id="Messenger_MM">
+          <person xml:id="Messenger_MM" sex="MALE">
             <persName>Messenger</persName>
           </person>
-          <person xml:id="Barnardine_MM">
+          <person xml:id="Barnardine_MM" sex="MALE">
             <persName>Barnardine</persName>
           </person>
-          <person xml:id="FriarPeter_MM">
+          <person xml:id="FriarPeter_MM" sex="MALE">
             <persName>Friar Peter</persName>
           </person>
         </listPerson>

--- a/tei/much-ado-about-nothing.xml
+++ b/tei/much-ado-about-nothing.xml
@@ -88,82 +88,82 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Leonato_Ado">
+          <person xml:id="Leonato_Ado" sex="MALE">
             <persName>Leonato</persName>
           </person>
-          <person xml:id="MESSENGERS.LEONATO.1_Ado">
+          <person xml:id="MESSENGERS.LEONATO.1_Ado" sex="MALE">
             <persName>Messenger</persName>
           </person>
-          <person xml:id="Beatrice_Ado">
+          <person xml:id="Beatrice_Ado" sex="FEMALE">
             <persName>Beatrice</persName>
           </person>
-          <person xml:id="Hero_Ado">
+          <person xml:id="Hero_Ado" sex="FEMALE">
             <persName>Hero</persName>
           </person>
-          <person xml:id="DonPedro_Ado">
+          <person xml:id="DonPedro_Ado" sex="MALE">
             <persName>Don Pedro</persName>
           </person>
-          <person xml:id="Benedick_Ado">
+          <person xml:id="Benedick_Ado" sex="MALE">
             <persName>Signior Benedick</persName>
           </person>
-          <person xml:id="DonJohn_Ado">
+          <person xml:id="DonJohn_Ado" sex="MALE">
             <persName>Don John</persName>
           </person>
-          <person xml:id="Claudio_Ado">
+          <person xml:id="Claudio_Ado" sex="MALE">
             <persName>Count Claudio</persName>
           </person>
-          <person xml:id="LeonatosBrother_Ado">
+          <person xml:id="LeonatosBrother_Ado" sex="MALE">
             <persName>Leonato’s Brother</persName>
           </person>
-          <person xml:id="Conrade_Ado">
+          <person xml:id="Conrade_Ado" sex="MALE">
             <persName>Conrade</persName>
           </person>
-          <person xml:id="Borachio_Ado">
+          <person xml:id="Borachio_Ado" sex="MALE">
             <persName>Borachio</persName>
           </person>
-          <person xml:id="Margaret_Ado">
+          <person xml:id="Margaret_Ado" sex="FEMALE">
             <persName>Margaret</persName>
           </person>
-          <person xml:id="Balthasar_Ado">
+          <person xml:id="Balthasar_Ado" sex="MALE">
             <persName>Balthasar</persName>
           </person>
-          <person xml:id="Ursula_Ado">
+          <person xml:id="Ursula_Ado" sex="FEMALE">
             <persName>Ursula</persName>
           </person>
-          <person xml:id="Antonio_Ado">
+          <person xml:id="Antonio_Ado" sex="MALE">
             <persName>Signior Antonio</persName>
           </person>
-          <person xml:id="Boy_Ado">
+          <person xml:id="Boy_Ado" sex="MALE">
             <persName>Boy</persName>
           </person>
-          <person xml:id="Dogberry_Ado">
+          <person xml:id="Dogberry_Ado" sex="MALE">
             <persName>Dogberry</persName>
           </person>
-          <person xml:id="Verges_Ado">
+          <person xml:id="Verges_Ado" sex="MALE">
             <persName>Verges</persName>
           </person>
-          <person xml:id="WATCHMEN.1_Ado">
+          <person xml:id="WATCHMEN.1_Ado" sex="MALE">
             <persName>First Watchman</persName>
           </person>
-          <person xml:id="WATCHMEN.Seacoal_Ado">
+          <person xml:id="WATCHMEN.Seacoal_Ado" sex="UNKNOWN">
             <persName>George Seacoal</persName>
           </person>
-          <person xml:id="WATCHMEN.2_Ado">
+          <person xml:id="WATCHMEN.2_Ado" sex="MALE">
             <persName>Second Watchman</persName>
           </person>
-          <person xml:id="FriarFrancis_Ado">
+          <person xml:id="FriarFrancis_Ado" sex="MALE">
             <persName>Friar Francis</persName>
           </person>
-          <person xml:id="Sexton_Ado">
+          <person xml:id="Sexton_Ado" sex="MALE">
             <persName>Sexton</persName>
           </person>
-          <person xml:id="ATTENDANTS.0.1_Ado">
-            <persName>Musicians, Lords, Attendants, Son to Leonato’s brother</persName>
-          </person>
-          <person xml:id="MUSICIANS_Ado">
-            <persName>Musicians, Lords, Attendants, Son to Leonato’s brother</persName>
-          </person>
-          <person xml:id="MESSENGERS.DONPEDRO.1_Ado">
+          <personGrp xml:id="ATTENDANTS.0.1_Ado" sex="UNKNOWN">
+            <name>Musicians, Lords, Attendants, Son to Leonato’s brother</name>
+          </personGrp>
+          <personGrp xml:id="MUSICIANS_Ado" sex="UNKNOWN">
+            <name>Musicians, Lords, Attendants, Son to Leonato’s brother</name>
+          </personGrp>
+          <person xml:id="MESSENGERS.DONPEDRO.1_Ado" sex="MALE">
             <persName>Messenger</persName>
           </person>
         </listPerson>

--- a/tei/much-ado-about-nothing.xml
+++ b/tei/much-ado-about-nothing.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,89 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Leonato_Ado"><persName>Leonato</persName></person><person xml:id="MESSENGERS.LEONATO.1_Ado"><persName>Messenger</persName></person><person xml:id="Beatrice_Ado"><persName>Beatrice</persName></person><person xml:id="Hero_Ado"><persName>Hero</persName></person><person xml:id="DonPedro_Ado"><persName>Don Pedro</persName></person><person xml:id="Benedick_Ado"><persName>Signior Benedick</persName></person><person xml:id="DonJohn_Ado"><persName>Don John</persName></person><person xml:id="Claudio_Ado"><persName>Count Claudio</persName></person><person xml:id="LeonatosBrother_Ado"><persName>Leonato’s Brother</persName></person><person xml:id="Conrade_Ado"><persName>Conrade</persName></person><person xml:id="Borachio_Ado"><persName>Borachio</persName></person><person xml:id="Margaret_Ado"><persName>Margaret</persName></person><person xml:id="Balthasar_Ado"><persName>Balthasar</persName></person><person xml:id="Ursula_Ado"><persName>Ursula</persName></person><person xml:id="Antonio_Ado"><persName>Signior Antonio</persName></person><person xml:id="Boy_Ado"><persName>Boy</persName></person><person xml:id="Dogberry_Ado"><persName>Dogberry</persName></person><person xml:id="Verges_Ado"><persName>Verges</persName></person><person xml:id="WATCHMEN.1_Ado"><persName>First Watchman</persName></person><person xml:id="WATCHMEN.Seacoal_Ado"><persName>George Seacoal</persName></person><person xml:id="WATCHMEN.2_Ado"><persName>Second Watchman</persName></person><person xml:id="FriarFrancis_Ado"><persName>Friar Francis</persName></person><person xml:id="Sexton_Ado"><persName>Sexton</persName></person><person xml:id="ATTENDANTS.0.1_Ado"><persName>Musicians, Lords, Attendants, Son to Leonato’s brother</persName></person><person xml:id="MUSICIANS_Ado"><persName>Musicians, Lords, Attendants, Son to Leonato’s brother</persName></person><person xml:id="MESSENGERS.DONPEDRO.1_Ado"><persName>Messenger</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Leonato_Ado">
+            <persName>Leonato</persName>
+          </person>
+          <person xml:id="MESSENGERS.LEONATO.1_Ado">
+            <persName>Messenger</persName>
+          </person>
+          <person xml:id="Beatrice_Ado">
+            <persName>Beatrice</persName>
+          </person>
+          <person xml:id="Hero_Ado">
+            <persName>Hero</persName>
+          </person>
+          <person xml:id="DonPedro_Ado">
+            <persName>Don Pedro</persName>
+          </person>
+          <person xml:id="Benedick_Ado">
+            <persName>Signior Benedick</persName>
+          </person>
+          <person xml:id="DonJohn_Ado">
+            <persName>Don John</persName>
+          </person>
+          <person xml:id="Claudio_Ado">
+            <persName>Count Claudio</persName>
+          </person>
+          <person xml:id="LeonatosBrother_Ado">
+            <persName>Leonato’s Brother</persName>
+          </person>
+          <person xml:id="Conrade_Ado">
+            <persName>Conrade</persName>
+          </person>
+          <person xml:id="Borachio_Ado">
+            <persName>Borachio</persName>
+          </person>
+          <person xml:id="Margaret_Ado">
+            <persName>Margaret</persName>
+          </person>
+          <person xml:id="Balthasar_Ado">
+            <persName>Balthasar</persName>
+          </person>
+          <person xml:id="Ursula_Ado">
+            <persName>Ursula</persName>
+          </person>
+          <person xml:id="Antonio_Ado">
+            <persName>Signior Antonio</persName>
+          </person>
+          <person xml:id="Boy_Ado">
+            <persName>Boy</persName>
+          </person>
+          <person xml:id="Dogberry_Ado">
+            <persName>Dogberry</persName>
+          </person>
+          <person xml:id="Verges_Ado">
+            <persName>Verges</persName>
+          </person>
+          <person xml:id="WATCHMEN.1_Ado">
+            <persName>First Watchman</persName>
+          </person>
+          <person xml:id="WATCHMEN.Seacoal_Ado">
+            <persName>George Seacoal</persName>
+          </person>
+          <person xml:id="WATCHMEN.2_Ado">
+            <persName>Second Watchman</persName>
+          </person>
+          <person xml:id="FriarFrancis_Ado">
+            <persName>Friar Francis</persName>
+          </person>
+          <person xml:id="Sexton_Ado">
+            <persName>Sexton</persName>
+          </person>
+          <person xml:id="ATTENDANTS.0.1_Ado">
+            <persName>Musicians, Lords, Attendants, Son to Leonato’s brother</persName>
+          </person>
+          <person xml:id="MUSICIANS_Ado">
+            <persName>Musicians, Lords, Attendants, Son to Leonato’s brother</persName>
+          </person>
+          <person xml:id="MESSENGERS.DONPEDRO.1_Ado">
+            <persName>Messenger</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/othello.xml
+++ b/tei/othello.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,95 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Roderigo_Oth"><persName>Roderigo</persName></person><person xml:id="Iago_Oth"><persName>Iago</persName></person><person xml:id="Brabantio_Oth"><persName>Brabantio</persName></person><person xml:id="Othello_Oth"><persName>Othello</persName></person><person xml:id="Cassio_Oth"><persName>Cassio</persName></person><person xml:id="OFFICERS_Oth"><persName>Servants, Attendants, Officers, Messengers, Herald, Musicians, Torchbearers.</persName></person><person xml:id="Duke_Oth"><persName>Duke_Oth</persName></person><person xml:id="SENATORS.0.1_Oth"><persName>SENATORS.0.1_Oth</persName></person><person xml:id="SENATORS.0.2_Oth"><persName>SENATORS.0.2_Oth</persName></person><person xml:id="Sailor_Oth"><persName>Sailors</persName></person><person xml:id="OFFICERS.0.1_Oth"><persName>Servants, Attendants, Officers, Messengers, Herald, Musicians, Torchbearers.</persName></person><person xml:id="MESSENGERS.X.1_Oth"><persName>Servants, Attendants, Officers, Messengers, Herald, Musicians, Torchbearers.</persName></person><person xml:id="SENATORS_Oth"><persName>Venetian senators</persName></person><person xml:id="Desdemona_Oth"><persName>Desdemona</persName></person><person xml:id="Montano_Oth"><persName>Montano</persName></person><person xml:id="GENTLEMEN.1_Oth"><persName>GENTLEMEN.1_Oth</persName></person><person xml:id="GENTLEMEN.2_Oth"><persName>GENTLEMEN.2_Oth</persName></person><person xml:id="GENTLEMEN.3_Oth"><persName>GENTLEMEN.3_Oth</persName></person><person xml:id="MESSENGERS.X.2_Oth"><persName>Servants, Attendants, Officers, Messengers, Herald, Musicians, Torchbearers.</persName></person><person xml:id="Emilia_Oth"><persName>Emilia</persName></person><person xml:id="Herald_Oth"><persName>Servants, Attendants, Officers, Messengers, Herald, Musicians, Torchbearers.</persName></person><person xml:id="GENTLEMEN_Oth"><persName>Gentlemen of Cyprus</persName></person><person xml:id="Clown_Oth"><persName>Clown_Oth</persName></person><person xml:id="MUSICIANS.0.1_Oth"><persName>Servants, Attendants, Officers, Messengers, Herald, Musicians, Torchbearers.</persName></person><person xml:id="GENTLEMEN.0.1_Oth"><persName>GENTLEMEN.0.1_Oth</persName></person><person xml:id="Bianca_Oth"><persName>Bianca</persName></person><person xml:id="Lodovico_Oth"><persName>Lodovico</persName></person><person xml:id="Gratiano_Oth"><persName>Gratiano</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Roderigo_Oth">
+            <persName>Roderigo</persName>
+          </person>
+          <person xml:id="Iago_Oth">
+            <persName>Iago</persName>
+          </person>
+          <person xml:id="Brabantio_Oth">
+            <persName>Brabantio</persName>
+          </person>
+          <person xml:id="Othello_Oth">
+            <persName>Othello</persName>
+          </person>
+          <person xml:id="Cassio_Oth">
+            <persName>Cassio</persName>
+          </person>
+          <person xml:id="OFFICERS_Oth">
+            <persName>Servants, Attendants, Officers, Messengers, Herald, Musicians, Torchbearers.</persName>
+          </person>
+          <person xml:id="Duke_Oth">
+            <persName>Duke_Oth</persName>
+          </person>
+          <person xml:id="SENATORS.0.1_Oth">
+            <persName>SENATORS.0.1_Oth</persName>
+          </person>
+          <person xml:id="SENATORS.0.2_Oth">
+            <persName>SENATORS.0.2_Oth</persName>
+          </person>
+          <person xml:id="Sailor_Oth">
+            <persName>Sailors</persName>
+          </person>
+          <person xml:id="OFFICERS.0.1_Oth">
+            <persName>Servants, Attendants, Officers, Messengers, Herald, Musicians, Torchbearers.</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.1_Oth">
+            <persName>Servants, Attendants, Officers, Messengers, Herald, Musicians, Torchbearers.</persName>
+          </person>
+          <person xml:id="SENATORS_Oth">
+            <persName>Venetian senators</persName>
+          </person>
+          <person xml:id="Desdemona_Oth">
+            <persName>Desdemona</persName>
+          </person>
+          <person xml:id="Montano_Oth">
+            <persName>Montano</persName>
+          </person>
+          <person xml:id="GENTLEMEN.1_Oth">
+            <persName>GENTLEMEN.1_Oth</persName>
+          </person>
+          <person xml:id="GENTLEMEN.2_Oth">
+            <persName>GENTLEMEN.2_Oth</persName>
+          </person>
+          <person xml:id="GENTLEMEN.3_Oth">
+            <persName>GENTLEMEN.3_Oth</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.2_Oth">
+            <persName>Servants, Attendants, Officers, Messengers, Herald, Musicians, Torchbearers.</persName>
+          </person>
+          <person xml:id="Emilia_Oth">
+            <persName>Emilia</persName>
+          </person>
+          <person xml:id="Herald_Oth">
+            <persName>Servants, Attendants, Officers, Messengers, Herald, Musicians, Torchbearers.</persName>
+          </person>
+          <person xml:id="GENTLEMEN_Oth">
+            <persName>Gentlemen of Cyprus</persName>
+          </person>
+          <person xml:id="Clown_Oth">
+            <persName>Clown_Oth</persName>
+          </person>
+          <person xml:id="MUSICIANS.0.1_Oth">
+            <persName>Servants, Attendants, Officers, Messengers, Herald, Musicians, Torchbearers.</persName>
+          </person>
+          <person xml:id="GENTLEMEN.0.1_Oth">
+            <persName>GENTLEMEN.0.1_Oth</persName>
+          </person>
+          <person xml:id="Bianca_Oth">
+            <persName>Bianca</persName>
+          </person>
+          <person xml:id="Lodovico_Oth">
+            <persName>Lodovico</persName>
+          </person>
+          <person xml:id="Gratiano_Oth">
+            <persName>Gratiano</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/othello.xml
+++ b/tei/othello.xml
@@ -88,88 +88,88 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Roderigo_Oth">
+          <person xml:id="Roderigo_Oth" sex="MALE">
             <persName>Roderigo</persName>
           </person>
-          <person xml:id="Iago_Oth">
+          <person xml:id="Iago_Oth" sex="MALE">
             <persName>Iago</persName>
           </person>
-          <person xml:id="Brabantio_Oth">
+          <person xml:id="Brabantio_Oth" sex="MALE">
             <persName>Brabantio</persName>
           </person>
-          <person xml:id="Othello_Oth">
+          <person xml:id="Othello_Oth" sex="MALE">
             <persName>Othello</persName>
           </person>
-          <person xml:id="Cassio_Oth">
+          <person xml:id="Cassio_Oth" sex="MALE">
             <persName>Cassio</persName>
           </person>
-          <person xml:id="OFFICERS_Oth">
-            <persName>Servants, Attendants, Officers, Messengers, Herald, Musicians, Torchbearers.</persName>
-          </person>
-          <person xml:id="Duke_Oth">
+          <personGrp xml:id="OFFICERS_Oth" sex="UNKNOWN">
+            <name>Servants, Attendants, Officers, Messengers, Herald, Musicians, Torchbearers.</name>
+          </personGrp>
+          <person xml:id="Duke_Oth" sex="MALE">
             <persName>Duke_Oth</persName>
           </person>
-          <person xml:id="SENATORS.0.1_Oth">
+          <person xml:id="SENATORS.0.1_Oth" sex="MALE">
             <persName>SENATORS.0.1_Oth</persName>
           </person>
-          <person xml:id="SENATORS.0.2_Oth">
+          <person xml:id="SENATORS.0.2_Oth" sex="MALE">
             <persName>SENATORS.0.2_Oth</persName>
           </person>
-          <person xml:id="Sailor_Oth">
+          <person xml:id="Sailor_Oth" sex="MALE">
             <persName>Sailors</persName>
           </person>
-          <person xml:id="OFFICERS.0.1_Oth">
-            <persName>Servants, Attendants, Officers, Messengers, Herald, Musicians, Torchbearers.</persName>
-          </person>
-          <person xml:id="MESSENGERS.X.1_Oth">
-            <persName>Servants, Attendants, Officers, Messengers, Herald, Musicians, Torchbearers.</persName>
-          </person>
-          <person xml:id="SENATORS_Oth">
-            <persName>Venetian senators</persName>
-          </person>
-          <person xml:id="Desdemona_Oth">
+          <personGrp xml:id="OFFICERS.0.1_Oth" sex="UNKNOWN">
+            <name>Servants, Attendants, Officers, Messengers, Herald, Musicians, Torchbearers.</name>
+          </personGrp>
+          <personGrp xml:id="MESSENGERS.X.1_Oth" sex="UNKNOWN">
+            <name>Servants, Attendants, Officers, Messengers, Herald, Musicians, Torchbearers.</name>
+          </personGrp>
+          <personGrp xml:id="SENATORS_Oth" sex="UNKNOWN">
+            <name>Venetian senators</name>
+          </personGrp>
+          <person xml:id="Desdemona_Oth" sex="FEMALE">
             <persName>Desdemona</persName>
           </person>
-          <person xml:id="Montano_Oth">
+          <person xml:id="Montano_Oth" sex="MALE">
             <persName>Montano</persName>
           </person>
-          <person xml:id="GENTLEMEN.1_Oth">
+          <person xml:id="GENTLEMEN.1_Oth" sex="MALE">
             <persName>GENTLEMEN.1_Oth</persName>
           </person>
-          <person xml:id="GENTLEMEN.2_Oth">
+          <person xml:id="GENTLEMEN.2_Oth" sex="MALE">
             <persName>GENTLEMEN.2_Oth</persName>
           </person>
-          <person xml:id="GENTLEMEN.3_Oth">
+          <person xml:id="GENTLEMEN.3_Oth" sex="MALE">
             <persName>GENTLEMEN.3_Oth</persName>
           </person>
-          <person xml:id="MESSENGERS.X.2_Oth">
-            <persName>Servants, Attendants, Officers, Messengers, Herald, Musicians, Torchbearers.</persName>
-          </person>
-          <person xml:id="Emilia_Oth">
+          <personGrp xml:id="MESSENGERS.X.2_Oth" sex="UNKNOWN">
+            <name>Servants, Attendants, Officers, Messengers, Herald, Musicians, Torchbearers.</name>
+          </personGrp>
+          <person xml:id="Emilia_Oth" sex="FEMALE">
             <persName>Emilia</persName>
           </person>
-          <person xml:id="Herald_Oth">
-            <persName>Servants, Attendants, Officers, Messengers, Herald, Musicians, Torchbearers.</persName>
-          </person>
-          <person xml:id="GENTLEMEN_Oth">
-            <persName>Gentlemen of Cyprus</persName>
-          </person>
-          <person xml:id="Clown_Oth">
+          <personGrp xml:id="Herald_Oth" sex="UNKNOWN">
+            <name>Servants, Attendants, Officers, Messengers, Herald, Musicians, Torchbearers.</name>
+          </personGrp>
+          <personGrp xml:id="GENTLEMEN_Oth" sex="UNKNOWN">
+            <name>Gentlemen of Cyprus</name>
+          </personGrp>
+          <person xml:id="Clown_Oth" sex="MALE">
             <persName>Clown_Oth</persName>
           </person>
-          <person xml:id="MUSICIANS.0.1_Oth">
-            <persName>Servants, Attendants, Officers, Messengers, Herald, Musicians, Torchbearers.</persName>
-          </person>
-          <person xml:id="GENTLEMEN.0.1_Oth">
-            <persName>GENTLEMEN.0.1_Oth</persName>
-          </person>
-          <person xml:id="Bianca_Oth">
+          <personGrp xml:id="MUSICIANS.0.1_Oth" sex="UNKNOWN">
+            <name>Servants, Attendants, Officers, Messengers, Herald, Musicians, Torchbearers.</name>
+          </personGrp>
+          <personGrp xml:id="GENTLEMEN.0.1_Oth" sex="UNKNOWN">
+            <name>GENTLEMEN.0.1_Oth</name>
+          </personGrp>
+          <person xml:id="Bianca_Oth" sex="FEMALE">
             <persName>Bianca</persName>
           </person>
-          <person xml:id="Lodovico_Oth">
+          <person xml:id="Lodovico_Oth" sex="MALE">
             <persName>Lodovico</persName>
           </person>
-          <person xml:id="Gratiano_Oth">
+          <person xml:id="Gratiano_Oth" sex="MALE">
             <persName>Gratiano</persName>
           </person>
         </listPerson>

--- a/tei/pericles.xml
+++ b/tei/pericles.xml
@@ -88,166 +88,166 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Gower_Per">
+          <person xml:id="Gower_Per" sex="MALE">
             <persName>Gower</persName>
           </person>
-          <person xml:id="Antiochus_Per">
+          <person xml:id="Antiochus_Per" sex="MALE">
             <persName>Antiochus</persName>
           </person>
-          <person xml:id="Pericles_Per">
+          <person xml:id="Pericles_Per" ana="http://www.wikidata.org/entity/Q80398">
             <persName>Pericles</persName>
           </person>
-          <person xml:id="Daughter_Per">
+          <person xml:id="Daughter_Per" sex="FEMALE">
             <persName>Daughter</persName>
           </person>
-          <person xml:id="Thaliard_Per">
+          <person xml:id="Thaliard_Per" sex="MALE">
             <persName>Thaliard</persName>
           </person>
-          <person xml:id="MESSENGERS.ANTIOCH.1_Per">
+          <person xml:id="MESSENGERS.ANTIOCH.1_Per" sex="MALE">
             <persName>Messenger</persName>
           </person>
-          <person xml:id="LORDS.TYRE.0.1_Per">
+          <person xml:id="LORDS.TYRE.0.1_Per" sex="MALE">
             <persName>LORDS.TYRE.0.1_Per</persName>
           </person>
-          <person xml:id="LORDS.TYRE.0.2_Per">
+          <person xml:id="LORDS.TYRE.0.2_Per" sex="MALE">
             <persName>LORDS.TYRE.0.2_Per</persName>
           </person>
-          <person xml:id="Helicanus_Per">
+          <person xml:id="Helicanus_Per" sex="MALE">
             <persName>Helicanus</persName>
           </person>
-          <person xml:id="Cleon_Per">
+          <person xml:id="Cleon_Per" ana="http://www.wikidata.org/entity/Q298220">
             <persName>Cleon</persName>
           </person>
-          <person xml:id="Dionyza_Per">
+          <person xml:id="Dionyza_Per" sex="FEMALE">
             <persName>Dionyza</persName>
           </person>
-          <person xml:id="LORDS.TARSUS.1_Per">
+          <person xml:id="LORDS.TARSUS.1_Per" sex="MALE">
             <persName>Lord</persName>
           </person>
-          <person xml:id="CITIZENS.TARSUS_Per">
-            <persName>Followers of Antiochus, Attendants to Pericles, Attendants to Simonides, Squires to the five Knights, Tyrian gentlemen, Citizens of Tarsus, Ladies of Pentapolis, Servants to Cerimon, Companion to Marina, Priestesses in Diana’s temple, Messenger from Tyre</persName>
-          </person>
-          <person xml:id="FISHERMEN.1_Per">
+          <personGrp xml:id="CITIZENS.TARSUS_Per" sex="UNKNOWN">
+            <name>Followers of Antiochus, Attendants to Pericles, Attendants to Simonides, Squires to the five Knights, Tyrian gentlemen, Citizens of Tarsus, Ladies of Pentapolis, Servants to Cerimon, Companion to Marina, Priestesses in Diana’s temple, Messenger from Tyre</name>
+          </personGrp>
+          <person xml:id="FISHERMEN.1_Per" sex="MALE">
             <persName>FISHERMEN.1_Per</persName>
           </person>
-          <person xml:id="FISHERMEN.2_Per">
+          <person xml:id="FISHERMEN.2_Per" sex="MALE">
             <persName>FISHERMEN.2_Per</persName>
           </person>
-          <person xml:id="FISHERMEN.3_Per">
+          <person xml:id="FISHERMEN.3_Per" sex="MALE">
             <persName>FISHERMEN.3_Per</persName>
           </person>
-          <person xml:id="Simonides_Per">
+          <person xml:id="Simonides_Per" sex="MALE">
             <persName>Simonides</persName>
           </person>
-          <person xml:id="LORDS.PENTAPOLIS.0.1_Per">
+          <person xml:id="LORDS.PENTAPOLIS.0.1_Per" sex="MALE">
             <persName>LORDS.PENTAPOLIS.0.1_Per</persName>
           </person>
-          <person xml:id="Thaisa_Per">
+          <person xml:id="Thaisa_Per" sex="FEMALE">
             <persName>Thaisa</persName>
           </person>
-          <person xml:id="LORDS.PENTAPOLIS.0.2_Per">
+          <person xml:id="LORDS.PENTAPOLIS.0.2_Per" sex="MALE">
             <persName>LORDS.PENTAPOLIS.0.2_Per</persName>
           </person>
-          <person xml:id="LORDS.PENTAPOLIS.0.3_Per">
+          <person xml:id="LORDS.PENTAPOLIS.0.3_Per" sex="MALE">
             <persName>LORDS.PENTAPOLIS.0.3_Per</persName>
           </person>
-          <person xml:id="KNIGHTS_Per">
-            <persName>Knights</persName>
-          </person>
-          <person xml:id="Marshal_Per">
+          <personGrp xml:id="KNIGHTS_Per" sex="UNKNOWN">
+            <name>Knights</name>
+          </personGrp>
+          <person xml:id="Marshal_Per" sex="MALE">
             <persName>Marshal</persName>
           </person>
-          <person xml:id="KNIGHTS.0.1_Per">
+          <person xml:id="KNIGHTS.0.1_Per" sex="MALE">
             <persName>KNIGHTS.0.1_Per</persName>
           </person>
-          <person xml:id="LORDS.TYRE.Escanes_Per">
+          <person xml:id="LORDS.TYRE.Escanes_Per" sex="MALE">
             <persName>Escanes</persName>
           </person>
-          <person xml:id="LORDS.TYRE.0.3_Per">
+          <person xml:id="LORDS.TYRE.0.3_Per" sex="MALE">
             <persName>LORDS.TYRE.0.3_Per</persName>
           </person>
-          <person xml:id="LORDS.TYRE_Per">
-            <persName>LORDS</persName>
-          </person>
-          <person xml:id="KNIGHTS.0.2_Per">
+          <personGrp xml:id="LORDS.TYRE_Per" sex="UNKNOWN">
+            <name>LORDS</name>
+          </personGrp>
+          <person xml:id="KNIGHTS.0.2_Per" sex="MALE">
             <persName>KNIGHTS.0.2_Per</persName>
           </person>
-          <person xml:id="KNIGHTS.0.3_Per">
+          <person xml:id="KNIGHTS.0.3_Per" sex="MALE">
             <persName>KNIGHTS.0.3_Per</persName>
           </person>
-          <person xml:id="Lychorida_Per">
+          <person xml:id="Lychorida_Per" sex="FEMALE">
             <persName>Lychorida</persName>
           </person>
-          <person xml:id="SAILORS.1_Per">
+          <person xml:id="SAILORS.1_Per" sex="MALE">
             <persName>SAILORS.1_Per</persName>
           </person>
-          <person xml:id="SAILORS.2_Per">
+          <person xml:id="SAILORS.2_Per" sex="MALE">
             <persName>SAILORS.2_Per</persName>
           </person>
-          <person xml:id="Cerimon_Per">
+          <person xml:id="Cerimon_Per" sex="MALE">
             <persName>Lord Cerimon</persName>
           </person>
-          <person xml:id="Philemon_Per">
+          <person xml:id="Philemon_Per" sex="MALE">
             <persName>Philemon</persName>
           </person>
-          <person xml:id="SUPPLIANTS.1_Per">
+          <person xml:id="SUPPLIANTS.1_Per" sex="MALE">
             <persName>SUPPLIANTS.1_Per</persName>
           </person>
-          <person xml:id="GENTLEMEN.EPHESUS.1_Per">
+          <person xml:id="GENTLEMEN.EPHESUS.1_Per" sex="MALE">
             <persName>GENTLEMEN.EPHESUS.1_Per</persName>
           </person>
-          <person xml:id="GENTLEMEN.EPHESUS.2_Per">
+          <person xml:id="GENTLEMEN.EPHESUS.2_Per" sex="MALE">
             <persName>GENTLEMEN.EPHESUS.2_Per</persName>
           </person>
-          <person xml:id="SERVANTS.CERIMON.0.1_Per">
-            <persName>Servant</persName>
-          </person>
-          <person xml:id="Leonine_Per">
+          <personGrp xml:id="SERVANTS.CERIMON.0.1_Per" sex="UNKNOWN">
+            <name>Servant</name>
+          </personGrp>
+          <person xml:id="Leonine_Per" sex="MALE">
             <persName>Leonine</persName>
           </person>
-          <person xml:id="Marina_Per">
+          <person xml:id="Marina_Per" sex="FEMALE">
             <persName>Marina</persName>
           </person>
-          <person xml:id="PIRATES.0.1_Per">
+          <person xml:id="PIRATES.0.1_Per" sex="MALE">
             <persName>PIRATES.0.1_Per</persName>
           </person>
-          <person xml:id="PIRATES.0.2_Per">
+          <person xml:id="PIRATES.0.2_Per" sex="MALE">
             <persName>PIRATES.0.2_Per</persName>
           </person>
-          <person xml:id="PIRATES.0.3_Per">
+          <person xml:id="PIRATES.0.3_Per" sex="MALE">
             <persName>PIRATES.0.3_Per</persName>
           </person>
-          <person xml:id="Pander_Per">
+          <person xml:id="Pander_Per" sex="MALE">
             <persName>Pander</persName>
           </person>
-          <person xml:id="Bolt_Per">
+          <person xml:id="Bolt_Per" sex="MALE">
             <persName>Bolt</persName>
           </person>
-          <person xml:id="Bawd_Per">
+          <person xml:id="Bawd_Per" sex="FEMALE">
             <persName>Bawd</persName>
           </person>
-          <person xml:id="GENTLEMEN.MYTILENE.1_Per">
+          <person xml:id="GENTLEMEN.MYTILENE.1_Per" sex="MALE">
             <persName>GENTLEMEN.MYTILENE.1_Per</persName>
           </person>
-          <person xml:id="GENTLEMEN.MYTILENE.2_Per">
+          <person xml:id="GENTLEMEN.MYTILENE.2_Per" sex="MALE">
             <persName>GENTLEMEN.MYTILENE.2_Per</persName>
           </person>
-          <person xml:id="Lysimachus_Per">
+          <person xml:id="Lysimachus_Per" sex="MALE">
             <persName>Lysimachus</persName>
           </person>
-          <person xml:id="SAILORS.TYRE.1_Per">
+          <person xml:id="SAILORS.TYRE.1_Per" sex="MALE">
             <persName>Sailor</persName>
           </person>
-          <person xml:id="GENTLEMEN.TYRE.0.1_Per">
+          <person xml:id="GENTLEMEN.TYRE.0.1_Per" sex="MALE">
             <persName>Gentleman</persName>
           </person>
-          <person xml:id="SAILORS.MYTILENE.1_Per">
+          <person xml:id="SAILORS.MYTILENE.1_Per" sex="MALE">
             <persName>Sailor</persName>
           </person>
-          <person xml:id="LORDS.MYTILENE.0.1_Per">
+          <person xml:id="LORDS.MYTILENE.0.1_Per" sex="MALE">
             <persName>Lord</persName>
           </person>
-          <person xml:id="Diana_Per">
+          <person xml:id="Diana_Per" sex="FEMALE">
             <persName>Diana</persName>
           </person>
         </listPerson>

--- a/tei/pericles.xml
+++ b/tei/pericles.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,173 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Gower_Per"><persName>Gower</persName></person><person xml:id="Antiochus_Per"><persName>Antiochus</persName></person><person xml:id="Pericles_Per"><persName>Pericles</persName></person><person xml:id="Daughter_Per"><persName>Daughter</persName></person><person xml:id="Thaliard_Per"><persName>Thaliard</persName></person><person xml:id="MESSENGERS.ANTIOCH.1_Per"><persName>Messenger</persName></person><person xml:id="LORDS.TYRE.0.1_Per"><persName>LORDS.TYRE.0.1_Per</persName></person><person xml:id="LORDS.TYRE.0.2_Per"><persName>LORDS.TYRE.0.2_Per</persName></person><person xml:id="Helicanus_Per"><persName>Helicanus</persName></person><person xml:id="Cleon_Per"><persName>Cleon</persName></person><person xml:id="Dionyza_Per"><persName>Dionyza</persName></person><person xml:id="LORDS.TARSUS.1_Per"><persName>Lord</persName></person><person xml:id="CITIZENS.TARSUS_Per"><persName>Followers of Antiochus, Attendants to Pericles, Attendants to Simonides, Squires to the five Knights, Tyrian gentlemen, Citizens of Tarsus, Ladies of Pentapolis, Servants to Cerimon, Companion to Marina, Priestesses in Diana’s temple, Messenger from Tyre</persName></person><person xml:id="FISHERMEN.1_Per"><persName>FISHERMEN.1_Per</persName></person><person xml:id="FISHERMEN.2_Per"><persName>FISHERMEN.2_Per</persName></person><person xml:id="FISHERMEN.3_Per"><persName>FISHERMEN.3_Per</persName></person><person xml:id="Simonides_Per"><persName>Simonides</persName></person><person xml:id="LORDS.PENTAPOLIS.0.1_Per"><persName>LORDS.PENTAPOLIS.0.1_Per</persName></person><person xml:id="Thaisa_Per"><persName>Thaisa</persName></person><person xml:id="LORDS.PENTAPOLIS.0.2_Per"><persName>LORDS.PENTAPOLIS.0.2_Per</persName></person><person xml:id="LORDS.PENTAPOLIS.0.3_Per"><persName>LORDS.PENTAPOLIS.0.3_Per</persName></person><person xml:id="KNIGHTS_Per"><persName>Knights</persName></person><person xml:id="Marshal_Per"><persName>Marshal</persName></person><person xml:id="KNIGHTS.0.1_Per"><persName>KNIGHTS.0.1_Per</persName></person><person xml:id="LORDS.TYRE.Escanes_Per"><persName>Escanes</persName></person><person xml:id="LORDS.TYRE.0.3_Per"><persName>LORDS.TYRE.0.3_Per</persName></person><person xml:id="LORDS.TYRE_Per"><persName>LORDS</persName></person><person xml:id="KNIGHTS.0.2_Per"><persName>KNIGHTS.0.2_Per</persName></person><person xml:id="KNIGHTS.0.3_Per"><persName>KNIGHTS.0.3_Per</persName></person><person xml:id="Lychorida_Per"><persName>Lychorida</persName></person><person xml:id="SAILORS.1_Per"><persName>SAILORS.1_Per</persName></person><person xml:id="SAILORS.2_Per"><persName>SAILORS.2_Per</persName></person><person xml:id="Cerimon_Per"><persName>Lord Cerimon</persName></person><person xml:id="Philemon_Per"><persName>Philemon</persName></person><person xml:id="SUPPLIANTS.1_Per"><persName>SUPPLIANTS.1_Per</persName></person><person xml:id="GENTLEMEN.EPHESUS.1_Per"><persName>GENTLEMEN.EPHESUS.1_Per</persName></person><person xml:id="GENTLEMEN.EPHESUS.2_Per"><persName>GENTLEMEN.EPHESUS.2_Per</persName></person><person xml:id="SERVANTS.CERIMON.0.1_Per"><persName>Servant</persName></person><person xml:id="Leonine_Per"><persName>Leonine</persName></person><person xml:id="Marina_Per"><persName>Marina</persName></person><person xml:id="PIRATES.0.1_Per"><persName>PIRATES.0.1_Per</persName></person><person xml:id="PIRATES.0.2_Per"><persName>PIRATES.0.2_Per</persName></person><person xml:id="PIRATES.0.3_Per"><persName>PIRATES.0.3_Per</persName></person><person xml:id="Pander_Per"><persName>Pander</persName></person><person xml:id="Bolt_Per"><persName>Bolt</persName></person><person xml:id="Bawd_Per"><persName>Bawd</persName></person><person xml:id="GENTLEMEN.MYTILENE.1_Per"><persName>GENTLEMEN.MYTILENE.1_Per</persName></person><person xml:id="GENTLEMEN.MYTILENE.2_Per"><persName>GENTLEMEN.MYTILENE.2_Per</persName></person><person xml:id="Lysimachus_Per"><persName>Lysimachus</persName></person><person xml:id="SAILORS.TYRE.1_Per"><persName>Sailor</persName></person><person xml:id="GENTLEMEN.TYRE.0.1_Per"><persName>Gentleman</persName></person><person xml:id="SAILORS.MYTILENE.1_Per"><persName>Sailor</persName></person><person xml:id="LORDS.MYTILENE.0.1_Per"><persName>Lord</persName></person><person xml:id="Diana_Per"><persName>Diana</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Gower_Per">
+            <persName>Gower</persName>
+          </person>
+          <person xml:id="Antiochus_Per">
+            <persName>Antiochus</persName>
+          </person>
+          <person xml:id="Pericles_Per">
+            <persName>Pericles</persName>
+          </person>
+          <person xml:id="Daughter_Per">
+            <persName>Daughter</persName>
+          </person>
+          <person xml:id="Thaliard_Per">
+            <persName>Thaliard</persName>
+          </person>
+          <person xml:id="MESSENGERS.ANTIOCH.1_Per">
+            <persName>Messenger</persName>
+          </person>
+          <person xml:id="LORDS.TYRE.0.1_Per">
+            <persName>LORDS.TYRE.0.1_Per</persName>
+          </person>
+          <person xml:id="LORDS.TYRE.0.2_Per">
+            <persName>LORDS.TYRE.0.2_Per</persName>
+          </person>
+          <person xml:id="Helicanus_Per">
+            <persName>Helicanus</persName>
+          </person>
+          <person xml:id="Cleon_Per">
+            <persName>Cleon</persName>
+          </person>
+          <person xml:id="Dionyza_Per">
+            <persName>Dionyza</persName>
+          </person>
+          <person xml:id="LORDS.TARSUS.1_Per">
+            <persName>Lord</persName>
+          </person>
+          <person xml:id="CITIZENS.TARSUS_Per">
+            <persName>Followers of Antiochus, Attendants to Pericles, Attendants to Simonides, Squires to the five Knights, Tyrian gentlemen, Citizens of Tarsus, Ladies of Pentapolis, Servants to Cerimon, Companion to Marina, Priestesses in Diana’s temple, Messenger from Tyre</persName>
+          </person>
+          <person xml:id="FISHERMEN.1_Per">
+            <persName>FISHERMEN.1_Per</persName>
+          </person>
+          <person xml:id="FISHERMEN.2_Per">
+            <persName>FISHERMEN.2_Per</persName>
+          </person>
+          <person xml:id="FISHERMEN.3_Per">
+            <persName>FISHERMEN.3_Per</persName>
+          </person>
+          <person xml:id="Simonides_Per">
+            <persName>Simonides</persName>
+          </person>
+          <person xml:id="LORDS.PENTAPOLIS.0.1_Per">
+            <persName>LORDS.PENTAPOLIS.0.1_Per</persName>
+          </person>
+          <person xml:id="Thaisa_Per">
+            <persName>Thaisa</persName>
+          </person>
+          <person xml:id="LORDS.PENTAPOLIS.0.2_Per">
+            <persName>LORDS.PENTAPOLIS.0.2_Per</persName>
+          </person>
+          <person xml:id="LORDS.PENTAPOLIS.0.3_Per">
+            <persName>LORDS.PENTAPOLIS.0.3_Per</persName>
+          </person>
+          <person xml:id="KNIGHTS_Per">
+            <persName>Knights</persName>
+          </person>
+          <person xml:id="Marshal_Per">
+            <persName>Marshal</persName>
+          </person>
+          <person xml:id="KNIGHTS.0.1_Per">
+            <persName>KNIGHTS.0.1_Per</persName>
+          </person>
+          <person xml:id="LORDS.TYRE.Escanes_Per">
+            <persName>Escanes</persName>
+          </person>
+          <person xml:id="LORDS.TYRE.0.3_Per">
+            <persName>LORDS.TYRE.0.3_Per</persName>
+          </person>
+          <person xml:id="LORDS.TYRE_Per">
+            <persName>LORDS</persName>
+          </person>
+          <person xml:id="KNIGHTS.0.2_Per">
+            <persName>KNIGHTS.0.2_Per</persName>
+          </person>
+          <person xml:id="KNIGHTS.0.3_Per">
+            <persName>KNIGHTS.0.3_Per</persName>
+          </person>
+          <person xml:id="Lychorida_Per">
+            <persName>Lychorida</persName>
+          </person>
+          <person xml:id="SAILORS.1_Per">
+            <persName>SAILORS.1_Per</persName>
+          </person>
+          <person xml:id="SAILORS.2_Per">
+            <persName>SAILORS.2_Per</persName>
+          </person>
+          <person xml:id="Cerimon_Per">
+            <persName>Lord Cerimon</persName>
+          </person>
+          <person xml:id="Philemon_Per">
+            <persName>Philemon</persName>
+          </person>
+          <person xml:id="SUPPLIANTS.1_Per">
+            <persName>SUPPLIANTS.1_Per</persName>
+          </person>
+          <person xml:id="GENTLEMEN.EPHESUS.1_Per">
+            <persName>GENTLEMEN.EPHESUS.1_Per</persName>
+          </person>
+          <person xml:id="GENTLEMEN.EPHESUS.2_Per">
+            <persName>GENTLEMEN.EPHESUS.2_Per</persName>
+          </person>
+          <person xml:id="SERVANTS.CERIMON.0.1_Per">
+            <persName>Servant</persName>
+          </person>
+          <person xml:id="Leonine_Per">
+            <persName>Leonine</persName>
+          </person>
+          <person xml:id="Marina_Per">
+            <persName>Marina</persName>
+          </person>
+          <person xml:id="PIRATES.0.1_Per">
+            <persName>PIRATES.0.1_Per</persName>
+          </person>
+          <person xml:id="PIRATES.0.2_Per">
+            <persName>PIRATES.0.2_Per</persName>
+          </person>
+          <person xml:id="PIRATES.0.3_Per">
+            <persName>PIRATES.0.3_Per</persName>
+          </person>
+          <person xml:id="Pander_Per">
+            <persName>Pander</persName>
+          </person>
+          <person xml:id="Bolt_Per">
+            <persName>Bolt</persName>
+          </person>
+          <person xml:id="Bawd_Per">
+            <persName>Bawd</persName>
+          </person>
+          <person xml:id="GENTLEMEN.MYTILENE.1_Per">
+            <persName>GENTLEMEN.MYTILENE.1_Per</persName>
+          </person>
+          <person xml:id="GENTLEMEN.MYTILENE.2_Per">
+            <persName>GENTLEMEN.MYTILENE.2_Per</persName>
+          </person>
+          <person xml:id="Lysimachus_Per">
+            <persName>Lysimachus</persName>
+          </person>
+          <person xml:id="SAILORS.TYRE.1_Per">
+            <persName>Sailor</persName>
+          </person>
+          <person xml:id="GENTLEMEN.TYRE.0.1_Per">
+            <persName>Gentleman</persName>
+          </person>
+          <person xml:id="SAILORS.MYTILENE.1_Per">
+            <persName>Sailor</persName>
+          </person>
+          <person xml:id="LORDS.MYTILENE.0.1_Per">
+            <persName>Lord</persName>
+          </person>
+          <person xml:id="Diana_Per">
+            <persName>Diana</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/richard-ii.xml
+++ b/tei/richard-ii.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,120 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="RichardII_R2"><persName>King Richard II</persName></person><person xml:id="Gaunt_R2"><persName>John of Gaunt</persName></person><person xml:id="HenryIV_1H4"><persName>Henry Bolingbroke Hereford</persName><persName>Henry Bolingbroke Hereford</persName></person><person xml:id="Mowbray_R2"><persName>Mowbray</persName></person><person xml:id="DuchessOfGloucester_R2"><persName>Duchess of Gloucester</persName></person><person xml:id="LordMarshal_R2"><persName>Lord Marshal</persName></person><person xml:id="Aumerle_R2"><persName>Duke of Aumerle</persName></person><person xml:id="HERALDS.1_R2"><persName>First Herald</persName></person><person xml:id="HERALDS.2_R2"><persName>Second Herald</persName></person><person xml:id="Green_R2"><persName>Green</persName></person><person xml:id="Bushy_R2"><persName>Bushy</persName></person><person xml:id="Bagot_R2"><persName>Bagot</persName></person><person xml:id="York_R2"><persName>Duke of York</persName></person><person xml:id="Queen_R2"><persName>Queen</persName></person><person xml:id="Northumberland_R2"><persName>Earl of Northumberland</persName></person><person xml:id="Ross_R2"><persName>Lord Ross</persName></person><person xml:id="Willoughby_R2"><persName>Lord Willoughby</persName></person><person xml:id="SERVANTS.YORK.1_R2"><persName>Servingmen</persName></person><person xml:id="Hotspur_R2"><persName>Harry Percy</persName></person><person xml:id="Berkeley_R2"><persName>Lord Berkeley</persName></person><person xml:id="WelshCaptain_R2"><persName>Welsh Captain</persName></person><person xml:id="Salisbury_R2"><persName>Earl of Salisbury</persName></person><person xml:id="BishopOfCarlisle_R2"><persName>Bishop of Carlisle</persName></person><person xml:id="Scroop_R2"><persName>Sir Stephen Scroop</persName></person><person xml:id="LADIES.0.1_R2"><persName>LADIES.0.1_R2</persName></person><person xml:id="Gardener_R2"><persName>Gardener</persName></person><person xml:id="SERVANTS.GARDENER.1_R2"><persName>SERVANTS.GARDENER.1_R2</persName></person><person xml:id="Fitzwater_R2"><persName>Lord Fitzwater</persName></person><person xml:id="LORDS.1_R2"><persName>Another Lord</persName></person><person xml:id="Surrey_R2"><persName>Duke of Surrey</persName></person><person xml:id="AbbotOfWestminster_R2"><persName>Abbot of Westminster</persName></person><person xml:id="DuchessOfYork_R2"><persName>Duchess of York</persName></person><person xml:id="Exton_R2"><persName>Sir Pierce of Exton</persName></person><person xml:id="SERVANTS.EXTON.0.1_R2"><persName>SERVANTS.EXTON.0.1_R2</persName></person><person xml:id="Groom_R2"><persName>Groom</persName></person><person xml:id="Jailer_R2"><persName>Keeper</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="RichardII_R2">
+            <persName>King Richard II</persName>
+          </person>
+          <person xml:id="Gaunt_R2">
+            <persName>John of Gaunt</persName>
+          </person>
+          <person xml:id="HenryIV_1H4">
+            <persName>Henry Bolingbroke Hereford</persName>
+            <persName>Henry Bolingbroke Hereford</persName>
+          </person>
+          <person xml:id="Mowbray_R2">
+            <persName>Mowbray</persName>
+          </person>
+          <person xml:id="DuchessOfGloucester_R2">
+            <persName>Duchess of Gloucester</persName>
+          </person>
+          <person xml:id="LordMarshal_R2">
+            <persName>Lord Marshal</persName>
+          </person>
+          <person xml:id="Aumerle_R2">
+            <persName>Duke of Aumerle</persName>
+          </person>
+          <person xml:id="HERALDS.1_R2">
+            <persName>First Herald</persName>
+          </person>
+          <person xml:id="HERALDS.2_R2">
+            <persName>Second Herald</persName>
+          </person>
+          <person xml:id="Green_R2">
+            <persName>Green</persName>
+          </person>
+          <person xml:id="Bushy_R2">
+            <persName>Bushy</persName>
+          </person>
+          <person xml:id="Bagot_R2">
+            <persName>Bagot</persName>
+          </person>
+          <person xml:id="York_R2">
+            <persName>Duke of York</persName>
+          </person>
+          <person xml:id="Queen_R2">
+            <persName>Queen</persName>
+          </person>
+          <person xml:id="Northumberland_R2">
+            <persName>Earl of Northumberland</persName>
+          </person>
+          <person xml:id="Ross_R2">
+            <persName>Lord Ross</persName>
+          </person>
+          <person xml:id="Willoughby_R2">
+            <persName>Lord Willoughby</persName>
+          </person>
+          <person xml:id="SERVANTS.YORK.1_R2">
+            <persName>Servingmen</persName>
+          </person>
+          <person xml:id="Hotspur_R2">
+            <persName>Harry Percy</persName>
+          </person>
+          <person xml:id="Berkeley_R2">
+            <persName>Lord Berkeley</persName>
+          </person>
+          <person xml:id="WelshCaptain_R2">
+            <persName>Welsh Captain</persName>
+          </person>
+          <person xml:id="Salisbury_R2">
+            <persName>Earl of Salisbury</persName>
+          </person>
+          <person xml:id="BishopOfCarlisle_R2">
+            <persName>Bishop of Carlisle</persName>
+          </person>
+          <person xml:id="Scroop_R2">
+            <persName>Sir Stephen Scroop</persName>
+          </person>
+          <person xml:id="LADIES.0.1_R2">
+            <persName>LADIES.0.1_R2</persName>
+          </person>
+          <person xml:id="Gardener_R2">
+            <persName>Gardener</persName>
+          </person>
+          <person xml:id="SERVANTS.GARDENER.1_R2">
+            <persName>SERVANTS.GARDENER.1_R2</persName>
+          </person>
+          <person xml:id="Fitzwater_R2">
+            <persName>Lord Fitzwater</persName>
+          </person>
+          <person xml:id="LORDS.1_R2">
+            <persName>Another Lord</persName>
+          </person>
+          <person xml:id="Surrey_R2">
+            <persName>Duke of Surrey</persName>
+          </person>
+          <person xml:id="AbbotOfWestminster_R2">
+            <persName>Abbot of Westminster</persName>
+          </person>
+          <person xml:id="DuchessOfYork_R2">
+            <persName>Duchess of York</persName>
+          </person>
+          <person xml:id="Exton_R2">
+            <persName>Sir Pierce of Exton</persName>
+          </person>
+          <person xml:id="SERVANTS.EXTON.0.1_R2">
+            <persName>SERVANTS.EXTON.0.1_R2</persName>
+          </person>
+          <person xml:id="Groom_R2">
+            <persName>Groom</persName>
+          </person>
+          <person xml:id="Jailer_R2">
+            <persName>Keeper</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/richard-ii.xml
+++ b/tei/richard-ii.xml
@@ -88,113 +88,113 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="RichardII_R2">
+          <person xml:id="RichardII_R2" ana="http://www.wikidata.org/entity/Q81000">
             <persName>King Richard II</persName>
           </person>
-          <person xml:id="Gaunt_R2">
+          <person xml:id="Gaunt_R2" ana="http://www.wikidata.org/entity/Q193752">
             <persName>John of Gaunt</persName>
           </person>
-          <person xml:id="HenryIV_1H4">
+          <person xml:id="HenryIV_1H4" ana="http://www.wikidata.org/entity/Q161866">
             <persName>Henry Bolingbroke Hereford</persName>
             <persName>Henry Bolingbroke Hereford</persName>
           </person>
-          <person xml:id="Mowbray_R2">
+          <person xml:id="Mowbray_R2" ana="http://www.wikidata.org/entity/Q711992">
             <persName>Mowbray</persName>
           </person>
-          <person xml:id="DuchessOfGloucester_R2">
+          <person xml:id="DuchessOfGloucester_R2" ana="http://www.wikidata.org/entity/Q2548323">
             <persName>Duchess of Gloucester</persName>
           </person>
-          <person xml:id="LordMarshal_R2">
+          <person xml:id="LordMarshal_R2" ana="http://www.wikidata.org/entity/Q1265164">
             <persName>Lord Marshal</persName>
           </person>
-          <person xml:id="Aumerle_R2">
+          <person xml:id="Aumerle_R2" ana="http://www.wikidata.org/entity/Q452639">
             <persName>Duke of Aumerle</persName>
           </person>
-          <person xml:id="HERALDS.1_R2">
+          <person xml:id="HERALDS.1_R2" sex="MALE">
             <persName>First Herald</persName>
           </person>
-          <person xml:id="HERALDS.2_R2">
+          <person xml:id="HERALDS.2_R2" sex="MALE">
             <persName>Second Herald</persName>
           </person>
-          <person xml:id="Green_R2">
+          <person xml:id="Green_R2" ana="http://www.wikidata.org/entity/Q5722188">
             <persName>Green</persName>
           </person>
-          <person xml:id="Bushy_R2">
+          <person xml:id="Bushy_R2" ana="http://www.wikidata.org/entity/Q6224092">
             <persName>Bushy</persName>
           </person>
-          <person xml:id="Bagot_R2">
+          <person xml:id="Bagot_R2" ana="http://www.wikidata.org/entity/Q8004925">
             <persName>Bagot</persName>
           </person>
-          <person xml:id="York_R2">
+          <person xml:id="York_R2" ana="http://www.wikidata.org/entity/Q305002">
             <persName>Duke of York</persName>
           </person>
-          <person xml:id="Queen_R2">
+          <person xml:id="Queen_R2" ana="http://www.wikidata.org/entity/Q170202">
             <persName>Queen</persName>
           </person>
-          <person xml:id="Northumberland_R2">
+          <person xml:id="Northumberland_R2" ana="http://www.wikidata.org/entity/Q1398378">
             <persName>Earl of Northumberland</persName>
           </person>
-          <person xml:id="Ross_R2">
+          <person xml:id="Ross_R2" ana="http://www.wikidata.org/entity/Q8020820">
             <persName>Lord Ross</persName>
           </person>
-          <person xml:id="Willoughby_R2">
+          <person xml:id="Willoughby_R2" ana="http://www.wikidata.org/entity/Q2581065">
             <persName>Lord Willoughby</persName>
           </person>
-          <person xml:id="SERVANTS.YORK.1_R2">
+          <person xml:id="SERVANTS.YORK.1_R2" sex="MALE">
             <persName>Servingmen</persName>
           </person>
-          <person xml:id="Hotspur_R2">
+          <person xml:id="Hotspur_R2" ana="http://www.wikidata.org/entity/Q471421">
             <persName>Harry Percy</persName>
           </person>
-          <person xml:id="Berkeley_R2">
+          <person xml:id="Berkeley_R2" ana="http://www.wikidata.org/entity/Q7795453">
             <persName>Lord Berkeley</persName>
           </person>
-          <person xml:id="WelshCaptain_R2">
+          <person xml:id="WelshCaptain_R2" sex="MALE">
             <persName>Welsh Captain</persName>
           </person>
-          <person xml:id="Salisbury_R2">
+          <person xml:id="Salisbury_R2" ana="http://www.wikidata.org/entity/Q3020313">
             <persName>Earl of Salisbury</persName>
           </person>
-          <person xml:id="BishopOfCarlisle_R2">
+          <person xml:id="BishopOfCarlisle_R2" ana="http://www.wikidata.org/entity/Q7792397">
             <persName>Bishop of Carlisle</persName>
           </person>
-          <person xml:id="Scroop_R2">
+          <person xml:id="Scroop_R2" sex="MALE">
             <persName>Sir Stephen Scroop</persName>
           </person>
-          <person xml:id="LADIES.0.1_R2">
-            <persName>LADIES.0.1_R2</persName>
-          </person>
-          <person xml:id="Gardener_R2">
+          <personGrp xml:id="LADIES.0.1_R2" sex="UNKNOWN">
+            <name>LADIES.0.1_R2</name>
+          </personGrp>
+          <person xml:id="Gardener_R2" sex="MALE">
             <persName>Gardener</persName>
           </person>
-          <person xml:id="SERVANTS.GARDENER.1_R2">
+          <person xml:id="SERVANTS.GARDENER.1_R2" sex="UNKNOWN">
             <persName>SERVANTS.GARDENER.1_R2</persName>
           </person>
-          <person xml:id="Fitzwater_R2">
+          <person xml:id="Fitzwater_R2" ana="http://www.wikidata.org/entity/Q4862373">
             <persName>Lord Fitzwater</persName>
           </person>
-          <person xml:id="LORDS.1_R2">
+          <person xml:id="LORDS.1_R2" sex="MALE">
             <persName>Another Lord</persName>
           </person>
-          <person xml:id="Surrey_R2">
+          <person xml:id="Surrey_R2" ana="http://www.wikidata.org/entity/Q2501872">
             <persName>Duke of Surrey</persName>
           </person>
-          <person xml:id="AbbotOfWestminster_R2">
+          <person xml:id="AbbotOfWestminster_R2" ana="http://www.wikidata.org/entity/Q1747157">
             <persName>Abbot of Westminster</persName>
           </person>
-          <person xml:id="DuchessOfYork_R2">
+          <person xml:id="DuchessOfYork_R2" ana="http://www.wikidata.org/entity/Q434485">
             <persName>Duchess of York</persName>
           </person>
-          <person xml:id="Exton_R2">
+          <person xml:id="Exton_R2" sex="MALE">
             <persName>Sir Pierce of Exton</persName>
           </person>
-          <person xml:id="SERVANTS.EXTON.0.1_R2">
+          <person xml:id="SERVANTS.EXTON.0.1_R2" sex="UNKNOWN">
             <persName>SERVANTS.EXTON.0.1_R2</persName>
           </person>
-          <person xml:id="Groom_R2">
+          <person xml:id="Groom_R2" sex="MALE">
             <persName>Groom</persName>
           </person>
-          <person xml:id="Jailer_R2">
+          <person xml:id="Jailer_R2" sex="MALE">
             <persName>Keeper</persName>
           </person>
         </listPerson>

--- a/tei/richard-iii.xml
+++ b/tei/richard-iii.xml
@@ -88,183 +88,183 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="RichardIII_R3">
+          <person xml:id="RichardIII_R3" ana="http://www.wikidata.org/entity/Q133028">
             <persName>Richard</persName>
           </person>
-          <person xml:id="Clarence_3H6">
+          <person xml:id="Clarence_3H6" sex="MALE">
             <persName>George, Duke of Clarence</persName>
           </person>
-          <person xml:id="Brakenbury_R3">
+          <person xml:id="Brakenbury_R3" ana="http://www.wikidata.org/entity/Q7342288">
             <persName>Sir Robert Brakenbury</persName>
           </person>
-          <person xml:id="Hastings_3H6">
+          <person xml:id="Hastings_3H6" sex="MALE">
             <persName>William, Lord Hastings</persName>
           </person>
-          <person xml:id="LadyAnne_R3">
+          <person xml:id="LadyAnne_R3" ana="http://www.wikidata.org/entity/Q1617538">
             <persName>Lady Anne</persName>
           </person>
-          <person xml:id="GENTLEMEN.0.1_R3">
+          <person xml:id="GENTLEMEN.0.1_R3" sex="MALE">
             <persName>Gentleman</persName>
           </person>
-          <person xml:id="Rivers_3H6">
+          <person xml:id="Rivers_3H6" sex="MALE">
             <persName>Earl Rivers</persName>
           </person>
-          <person xml:id="Grey_R3">
+          <person xml:id="Grey_R3" sex="MALE">
             <persName>Lord Grey</persName>
           </person>
-          <person xml:id="QueenElizabeth_3H6">
+          <person xml:id="QueenElizabeth_3H6" ana="http://www.wikidata.org/entity/Q7207">
             <persName>Queen Elizabeth</persName>
           </person>
-          <person xml:id="Buckingham_R3">
+          <person xml:id="Buckingham_R3" sex="MALE">
             <persName>Duke of Buckingham</persName>
           </person>
-          <person xml:id="Stanley_R3">
+          <person xml:id="Stanley_R3" sex="MALE">
             <persName>Lord Stanley</persName>
           </person>
-          <person xml:id="QueenMargaret_1H6">
+          <person xml:id="QueenMargaret_1H6" ana="http://www.wikidata.org/entity/Q231145">
             <persName>Queen Margaret</persName>
           </person>
-          <person xml:id="Dorset_R3">
+          <person xml:id="Dorset_R3" sex="MALE">
             <persName>Marquess of Dorset</persName>
           </person>
-          <person xml:id="Catesby_R3">
+          <person xml:id="Catesby_R3" ana="http://www.wikidata.org/entity/Q3568489">
             <persName>Sir William Catesby</persName>
           </person>
-          <person xml:id="MURDERERS.1_R3">
+          <person xml:id="MURDERERS.1_R3" sex="MALE">
             <persName>MURDERERS.1_R3</persName>
           </person>
-          <person xml:id="MURDERERS.2_R3">
+          <person xml:id="MURDERERS.2_R3" sex="MALE">
             <persName>MURDERERS.2_R3</persName>
           </person>
-          <person xml:id="Jailer_R3">
+          <person xml:id="Jailer_R3" sex="MALE">
             <persName>Keeper</persName>
           </person>
-          <person xml:id="EdwardIV_3H6">
+          <person xml:id="EdwardIV_3H6" ana="http://www.wikidata.org/entity/Q160341">
             <persName>King Edward IV</persName>
           </person>
-          <person xml:id="ClarencesBoy_R3">
+          <person xml:id="ClarencesBoy_R3" sex="MALE">
             <persName>Boy</persName>
           </person>
-          <person xml:id="DuchessOfYork_R3">
+          <person xml:id="DuchessOfYork_R3" sex="FEMALE">
             <persName>Duchess of York</persName>
           </person>
-          <person xml:id="ClarencesDaughter_R3">
+          <person xml:id="ClarencesDaughter_R3" sex="FEMALE">
             <persName>Daughter</persName>
           </person>
-          <person xml:id="CITIZENS.1_R3">
-            <persName>CITIZENS.1_R3</persName>
-          </person>
-          <person xml:id="CITIZENS.2_R3">
-            <persName>CITIZENS.2_R3</persName>
-          </person>
-          <person xml:id="CITIZENS.3_R3">
-            <persName>CITIZENS.3_R3</persName>
-          </person>
-          <person xml:id="Archbishop_R3">
+          <personGrp xml:id="CITIZENS.1_R3" sex="UNKNOWN">
+            <name>CITIZENS.1_R3</name>
+          </personGrp>
+          <personGrp xml:id="CITIZENS.2_R3" sex="UNKNOWN">
+            <name>CITIZENS.2_R3</name>
+          </personGrp>
+          <personGrp xml:id="CITIZENS.3_R3" sex="UNKNOWN">
+            <name>CITIZENS.3_R3</name>
+          </personGrp>
+          <person xml:id="Archbishop_R3" sex="MALE">
             <persName>Archbishop</persName>
           </person>
-          <person xml:id="York_R3">
+          <person xml:id="York_R3" sex="MALE">
             <persName>Richard, Duke of York</persName>
           </person>
-          <person xml:id="MESSENGERS.X.1_R3">
-            <persName>MESSENGERS.X.1_R3</persName>
-          </person>
-          <person xml:id="EdwardV_R3">
+          <personGrp xml:id="MESSENGERS.X.1_R3" sex="UNKNOWN">
+            <name>MESSENGERS.X.1_R3</name>
+          </personGrp>
+          <person xml:id="EdwardV_R3" ana="http://www.wikidata.org/entity/Q160341">
             <persName>Prince Edward</persName>
           </person>
-          <person xml:id="MayorOfLondon_R3">
+          <person xml:id="MayorOfLondon_R3" sex="MALE">
             <persName>Lord Mayor</persName>
           </person>
-          <person xml:id="Cardinal_R3">
+          <person xml:id="Cardinal_R3" sex="MALE">
             <persName>Cardinal</persName>
           </person>
-          <person xml:id="MESSENGERS.X.2_R3">
-            <persName>MESSENGERS.X.2_R3</persName>
-          </person>
-          <person xml:id="Pursuivant_R3">
+          <personGrp xml:id="MESSENGERS.X.2_R3" sex="UNKNOWN">
+            <name>MESSENGERS.X.2_R3</name>
+          </personGrp>
+          <person xml:id="Pursuivant_R3" sex="MALE">
             <persName>Pursuivant</persName>
           </person>
-          <person xml:id="SirJohn_R3">
+          <person xml:id="SirJohn_R3" sex="MALE">
             <persName>Sir John</persName>
           </person>
-          <person xml:id="Vaughan_R3">
+          <person xml:id="Vaughan_R3" sex="MALE">
             <persName>Sir Thomas Vaughan</persName>
           </person>
-          <person xml:id="Ratcliffe_R3">
+          <person xml:id="Ratcliffe_R3" sex="MALE">
             <persName>Sir Richard Ratcliffe</persName>
           </person>
-          <person xml:id="BishopOfEly_R3">
+          <person xml:id="BishopOfEly_R3" sex="MALE">
             <persName>John Morton, Bishop of Ely</persName>
           </person>
-          <person xml:id="Lovell_R3">
+          <person xml:id="Lovell_R3" sex="MALE">
             <persName>Lord Lovell</persName>
           </person>
-          <person xml:id="Scrivener_R3">
+          <person xml:id="Scrivener_R3" sex="MALE">
             <persName>Scrivener</persName>
           </person>
-          <person xml:id="BISHOPS_R3">
-            <persName>Guards, Tressel, Berkeley, Halberds, Gentlemen, Anthony Woodeville and Lord Scales (brothers to Queen Elizabeth), Two Bishops, Sir William Brandon, Lords, Attendants, Citizens, Aldermen, Councillors, Soldiers</persName>
-          </person>
-          <person xml:id="CITIZENS_R3">
-            <persName>Citizens</persName>
-          </person>
-          <person xml:id="ATTENDANTS.0.1_R3">
+          <personGrp xml:id="BISHOPS_R3" sex="UNKNOWN">
+            <name>Guards, Tressel, Berkeley, Halberds, Gentlemen, Anthony Woodeville and Lord Scales (brothers to Queen Elizabeth), Two Bishops, Sir William Brandon, Lords, Attendants, Citizens, Aldermen, Councillors, Soldiers</name>
+          </personGrp>
+          <personGrp xml:id="CITIZENS_R3" sex="UNKNOWN">
+            <name>Citizens</name>
+          </personGrp>
+          <person xml:id="ATTENDANTS.0.1_R3" sex="MALE">
             <persName>Page</persName>
           </person>
-          <person xml:id="Tyrrel_R3">
+          <person xml:id="Tyrrel_R3" sex="MALE">
             <persName>James Tyrrel</persName>
           </person>
-          <person xml:id="MESSENGERS.1_R3">
-            <persName>MESSENGERS.1_R3</persName>
-          </person>
-          <person xml:id="MESSENGERS.2_R3">
-            <persName>MESSENGERS.2_R3</persName>
-          </person>
-          <person xml:id="MESSENGERS.3_R3">
-            <persName>MESSENGERS.3_R3</persName>
-          </person>
-          <person xml:id="MESSENGERS.4_R3">
-            <persName>MESSENGERS.4_R3</persName>
-          </person>
-          <person xml:id="SirChristopher_R3">
+          <personGrp xml:id="MESSENGERS.1_R3" sex="UNKNOWN">
+            <name>MESSENGERS.1_R3</name>
+          </personGrp>
+          <personGrp xml:id="MESSENGERS.2_R3" sex="UNKNOWN">
+            <name>MESSENGERS.2_R3</name>
+          </personGrp>
+          <personGrp xml:id="MESSENGERS.3_R3" sex="UNKNOWN">
+            <name>MESSENGERS.3_R3</name>
+          </personGrp>
+          <personGrp xml:id="MESSENGERS.4_R3" sex="UNKNOWN">
+            <name>MESSENGERS.4_R3</name>
+          </personGrp>
+          <person xml:id="SirChristopher_R3" sex="MALE">
             <persName>Sir Christopher</persName>
           </person>
-          <person xml:id="Sheriff_R3">
+          <person xml:id="Sheriff_R3" sex="MALE">
             <persName>Sheriff</persName>
           </person>
-          <person xml:id="HenryVII_R3">
+          <person xml:id="HenryVII_R3" sex="MALE">
             <persName>Earl of Richmond</persName>
           </person>
-          <person xml:id="Oxford_3H6">
+          <person xml:id="Oxford_3H6" sex="MALE">
             <persName>Earl of Oxford</persName>
           </person>
-          <person xml:id="Herbert_R3">
+          <person xml:id="Herbert_R3" sex="MALE">
             <persName>Sir Walter Herbert</persName>
           </person>
-          <person xml:id="Blunt_R3">
+          <person xml:id="Blunt_R3" sex="MALE">
             <persName>Sir James Blunt</persName>
           </person>
-          <person xml:id="Surrey_R3">
+          <person xml:id="Surrey_R3" sex="MALE">
             <persName>Earl of Surrey</persName>
           </person>
-          <person xml:id="Norfolk_R3">
+          <person xml:id="Norfolk_R3" sex="MALE">
             <persName>Duke of Norfolk</persName>
           </person>
-          <person xml:id="PrinceEdward_3H6">
+          <person xml:id="PrinceEdward_3H6" sex="MALE">
             <persName>PrinceEdward_3H6</persName>
           </person>
-          <person xml:id="HenryVI_1H6">
+          <person xml:id="HenryVI_1H6" sex="MALE">
             <persName>HenryVI_1H6</persName>
           </person>
-          <person xml:id="ATTENDANTS.RICHMOND_R3">
-            <persName>Guards, Tressel, Berkeley, Halberds, Gentlemen, Anthony Woodeville and Lord Scales (brothers to Queen Elizabeth), Two Bishops, Sir William Brandon, Lords, Attendants, Citizens, Aldermen, Councillors, Soldiers</persName>
-          </person>
-          <person xml:id="ATTENDANTS.RICHMOND.0.1_R3">
-            <persName>Guards, Tressel, Berkeley, Halberds, Gentlemen, Anthony Woodeville and Lord Scales (brothers to Queen Elizabeth), Two Bishops, Sir William Brandon, Lords, Attendants, Citizens, Aldermen, Councillors, Soldiers</persName>
-          </person>
-          <person xml:id="MESSENGERS.X.3_R3">
-            <persName>MESSENGERS.X.3_R3</persName>
-          </person>
+          <personGrp xml:id="ATTENDANTS.RICHMOND_R3" sex="UNKNOWN">
+            <name>Guards, Tressel, Berkeley, Halberds, Gentlemen, Anthony Woodeville and Lord Scales (brothers to Queen Elizabeth), Two Bishops, Sir William Brandon, Lords, Attendants, Citizens, Aldermen, Councillors, Soldiers</name>
+          </personGrp>
+          <personGrp xml:id="ATTENDANTS.RICHMOND.0.1_R3" sex="UNKNOWN">
+            <name>Guards, Tressel, Berkeley, Halberds, Gentlemen, Anthony Woodeville and Lord Scales (brothers to Queen Elizabeth), Two Bishops, Sir William Brandon, Lords, Attendants, Citizens, Aldermen, Councillors, Soldiers</name>
+          </personGrp>
+          <personGrp xml:id="MESSENGERS.X.3_R3" sex="UNKNOWN">
+            <name>MESSENGERS.X.3_R3</name>
+          </personGrp>
         </listPerson>
       </particDesc>
     </profileDesc>

--- a/tei/richard-iii.xml
+++ b/tei/richard-iii.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,188 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="RichardIII_R3"><persName>Richard</persName></person><person xml:id="Clarence_3H6"><persName>George, Duke of Clarence</persName></person><person xml:id="Brakenbury_R3"><persName>Sir Robert Brakenbury</persName></person><person xml:id="Hastings_3H6"><persName>William, Lord Hastings</persName></person><person xml:id="LadyAnne_R3"><persName>Lady Anne</persName></person><person xml:id="GENTLEMEN.0.1_R3"><persName>Gentleman</persName></person><person xml:id="Rivers_3H6"><persName>Earl Rivers</persName></person><person xml:id="Grey_R3"><persName>Lord Grey</persName></person><person xml:id="QueenElizabeth_3H6"><persName>Queen Elizabeth</persName></person><person xml:id="Buckingham_R3"><persName>Duke of Buckingham</persName></person><person xml:id="Stanley_R3"><persName>Lord Stanley</persName></person><person xml:id="QueenMargaret_1H6"><persName>Queen Margaret</persName></person><person xml:id="Dorset_R3"><persName>Marquess of Dorset</persName></person><person xml:id="Catesby_R3"><persName>Sir William Catesby</persName></person><person xml:id="MURDERERS.1_R3"><persName>MURDERERS.1_R3</persName></person><person xml:id="MURDERERS.2_R3"><persName>MURDERERS.2_R3</persName></person><person xml:id="Jailer_R3"><persName>Keeper</persName></person><person xml:id="EdwardIV_3H6"><persName>King Edward IV</persName></person><person xml:id="ClarencesBoy_R3"><persName>Boy</persName></person><person xml:id="DuchessOfYork_R3"><persName>Duchess of York</persName></person><person xml:id="ClarencesDaughter_R3"><persName>Daughter</persName></person><person xml:id="CITIZENS.1_R3"><persName>CITIZENS.1_R3</persName></person><person xml:id="CITIZENS.2_R3"><persName>CITIZENS.2_R3</persName></person><person xml:id="CITIZENS.3_R3"><persName>CITIZENS.3_R3</persName></person><person xml:id="Archbishop_R3"><persName>Archbishop</persName></person><person xml:id="York_R3"><persName>Richard, Duke of York</persName></person><person xml:id="MESSENGERS.X.1_R3"><persName>MESSENGERS.X.1_R3</persName></person><person xml:id="EdwardV_R3"><persName>Prince Edward</persName></person><person xml:id="MayorOfLondon_R3"><persName>Lord Mayor</persName></person><person xml:id="Cardinal_R3"><persName>Cardinal</persName></person><person xml:id="MESSENGERS.X.2_R3"><persName>MESSENGERS.X.2_R3</persName></person><person xml:id="Pursuivant_R3"><persName>Pursuivant</persName></person><person xml:id="SirJohn_R3"><persName>Sir John</persName></person><person xml:id="Vaughan_R3"><persName>Sir Thomas Vaughan</persName></person><person xml:id="Ratcliffe_R3"><persName>Sir Richard Ratcliffe</persName></person><person xml:id="BishopOfEly_R3"><persName>John Morton, Bishop of Ely</persName></person><person xml:id="Lovell_R3"><persName>Lord Lovell</persName></person><person xml:id="Scrivener_R3"><persName>Scrivener</persName></person><person xml:id="BISHOPS_R3"><persName>Guards, Tressel, Berkeley, Halberds, Gentlemen, Anthony Woodeville and Lord Scales (brothers to Queen Elizabeth), Two Bishops, Sir William Brandon, Lords, Attendants, Citizens, Aldermen, Councillors, Soldiers</persName></person><person xml:id="CITIZENS_R3"><persName>Citizens</persName></person><person xml:id="ATTENDANTS.0.1_R3"><persName>Page</persName></person><person xml:id="Tyrrel_R3"><persName>James Tyrrel</persName></person><person xml:id="MESSENGERS.1_R3"><persName>MESSENGERS.1_R3</persName></person><person xml:id="MESSENGERS.2_R3"><persName>MESSENGERS.2_R3</persName></person><person xml:id="MESSENGERS.3_R3"><persName>MESSENGERS.3_R3</persName></person><person xml:id="MESSENGERS.4_R3"><persName>MESSENGERS.4_R3</persName></person><person xml:id="SirChristopher_R3"><persName>Sir Christopher</persName></person><person xml:id="Sheriff_R3"><persName>Sheriff</persName></person><person xml:id="HenryVII_R3"><persName>Earl of Richmond</persName></person><person xml:id="Oxford_3H6"><persName>Earl of Oxford</persName></person><person xml:id="Herbert_R3"><persName>Sir Walter Herbert</persName></person><person xml:id="Blunt_R3"><persName>Sir James Blunt</persName></person><person xml:id="Surrey_R3"><persName>Earl of Surrey</persName></person><person xml:id="Norfolk_R3"><persName>Duke of Norfolk</persName></person><person xml:id="PrinceEdward_3H6"><persName>PrinceEdward_3H6</persName></person><person xml:id="HenryVI_1H6"><persName>HenryVI_1H6</persName></person><person xml:id="ATTENDANTS.RICHMOND_R3"><persName>Guards, Tressel, Berkeley, Halberds, Gentlemen, Anthony Woodeville and Lord Scales (brothers to Queen Elizabeth), Two Bishops, Sir William Brandon, Lords, Attendants, Citizens, Aldermen, Councillors, Soldiers</persName></person><person xml:id="ATTENDANTS.RICHMOND.0.1_R3"><persName>Guards, Tressel, Berkeley, Halberds, Gentlemen, Anthony Woodeville and Lord Scales (brothers to Queen Elizabeth), Two Bishops, Sir William Brandon, Lords, Attendants, Citizens, Aldermen, Councillors, Soldiers</persName></person><person xml:id="MESSENGERS.X.3_R3"><persName>MESSENGERS.X.3_R3</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="RichardIII_R3">
+            <persName>Richard</persName>
+          </person>
+          <person xml:id="Clarence_3H6">
+            <persName>George, Duke of Clarence</persName>
+          </person>
+          <person xml:id="Brakenbury_R3">
+            <persName>Sir Robert Brakenbury</persName>
+          </person>
+          <person xml:id="Hastings_3H6">
+            <persName>William, Lord Hastings</persName>
+          </person>
+          <person xml:id="LadyAnne_R3">
+            <persName>Lady Anne</persName>
+          </person>
+          <person xml:id="GENTLEMEN.0.1_R3">
+            <persName>Gentleman</persName>
+          </person>
+          <person xml:id="Rivers_3H6">
+            <persName>Earl Rivers</persName>
+          </person>
+          <person xml:id="Grey_R3">
+            <persName>Lord Grey</persName>
+          </person>
+          <person xml:id="QueenElizabeth_3H6">
+            <persName>Queen Elizabeth</persName>
+          </person>
+          <person xml:id="Buckingham_R3">
+            <persName>Duke of Buckingham</persName>
+          </person>
+          <person xml:id="Stanley_R3">
+            <persName>Lord Stanley</persName>
+          </person>
+          <person xml:id="QueenMargaret_1H6">
+            <persName>Queen Margaret</persName>
+          </person>
+          <person xml:id="Dorset_R3">
+            <persName>Marquess of Dorset</persName>
+          </person>
+          <person xml:id="Catesby_R3">
+            <persName>Sir William Catesby</persName>
+          </person>
+          <person xml:id="MURDERERS.1_R3">
+            <persName>MURDERERS.1_R3</persName>
+          </person>
+          <person xml:id="MURDERERS.2_R3">
+            <persName>MURDERERS.2_R3</persName>
+          </person>
+          <person xml:id="Jailer_R3">
+            <persName>Keeper</persName>
+          </person>
+          <person xml:id="EdwardIV_3H6">
+            <persName>King Edward IV</persName>
+          </person>
+          <person xml:id="ClarencesBoy_R3">
+            <persName>Boy</persName>
+          </person>
+          <person xml:id="DuchessOfYork_R3">
+            <persName>Duchess of York</persName>
+          </person>
+          <person xml:id="ClarencesDaughter_R3">
+            <persName>Daughter</persName>
+          </person>
+          <person xml:id="CITIZENS.1_R3">
+            <persName>CITIZENS.1_R3</persName>
+          </person>
+          <person xml:id="CITIZENS.2_R3">
+            <persName>CITIZENS.2_R3</persName>
+          </person>
+          <person xml:id="CITIZENS.3_R3">
+            <persName>CITIZENS.3_R3</persName>
+          </person>
+          <person xml:id="Archbishop_R3">
+            <persName>Archbishop</persName>
+          </person>
+          <person xml:id="York_R3">
+            <persName>Richard, Duke of York</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.1_R3">
+            <persName>MESSENGERS.X.1_R3</persName>
+          </person>
+          <person xml:id="EdwardV_R3">
+            <persName>Prince Edward</persName>
+          </person>
+          <person xml:id="MayorOfLondon_R3">
+            <persName>Lord Mayor</persName>
+          </person>
+          <person xml:id="Cardinal_R3">
+            <persName>Cardinal</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.2_R3">
+            <persName>MESSENGERS.X.2_R3</persName>
+          </person>
+          <person xml:id="Pursuivant_R3">
+            <persName>Pursuivant</persName>
+          </person>
+          <person xml:id="SirJohn_R3">
+            <persName>Sir John</persName>
+          </person>
+          <person xml:id="Vaughan_R3">
+            <persName>Sir Thomas Vaughan</persName>
+          </person>
+          <person xml:id="Ratcliffe_R3">
+            <persName>Sir Richard Ratcliffe</persName>
+          </person>
+          <person xml:id="BishopOfEly_R3">
+            <persName>John Morton, Bishop of Ely</persName>
+          </person>
+          <person xml:id="Lovell_R3">
+            <persName>Lord Lovell</persName>
+          </person>
+          <person xml:id="Scrivener_R3">
+            <persName>Scrivener</persName>
+          </person>
+          <person xml:id="BISHOPS_R3">
+            <persName>Guards, Tressel, Berkeley, Halberds, Gentlemen, Anthony Woodeville and Lord Scales (brothers to Queen Elizabeth), Two Bishops, Sir William Brandon, Lords, Attendants, Citizens, Aldermen, Councillors, Soldiers</persName>
+          </person>
+          <person xml:id="CITIZENS_R3">
+            <persName>Citizens</persName>
+          </person>
+          <person xml:id="ATTENDANTS.0.1_R3">
+            <persName>Page</persName>
+          </person>
+          <person xml:id="Tyrrel_R3">
+            <persName>James Tyrrel</persName>
+          </person>
+          <person xml:id="MESSENGERS.1_R3">
+            <persName>MESSENGERS.1_R3</persName>
+          </person>
+          <person xml:id="MESSENGERS.2_R3">
+            <persName>MESSENGERS.2_R3</persName>
+          </person>
+          <person xml:id="MESSENGERS.3_R3">
+            <persName>MESSENGERS.3_R3</persName>
+          </person>
+          <person xml:id="MESSENGERS.4_R3">
+            <persName>MESSENGERS.4_R3</persName>
+          </person>
+          <person xml:id="SirChristopher_R3">
+            <persName>Sir Christopher</persName>
+          </person>
+          <person xml:id="Sheriff_R3">
+            <persName>Sheriff</persName>
+          </person>
+          <person xml:id="HenryVII_R3">
+            <persName>Earl of Richmond</persName>
+          </person>
+          <person xml:id="Oxford_3H6">
+            <persName>Earl of Oxford</persName>
+          </person>
+          <person xml:id="Herbert_R3">
+            <persName>Sir Walter Herbert</persName>
+          </person>
+          <person xml:id="Blunt_R3">
+            <persName>Sir James Blunt</persName>
+          </person>
+          <person xml:id="Surrey_R3">
+            <persName>Earl of Surrey</persName>
+          </person>
+          <person xml:id="Norfolk_R3">
+            <persName>Duke of Norfolk</persName>
+          </person>
+          <person xml:id="PrinceEdward_3H6">
+            <persName>PrinceEdward_3H6</persName>
+          </person>
+          <person xml:id="HenryVI_1H6">
+            <persName>HenryVI_1H6</persName>
+          </person>
+          <person xml:id="ATTENDANTS.RICHMOND_R3">
+            <persName>Guards, Tressel, Berkeley, Halberds, Gentlemen, Anthony Woodeville and Lord Scales (brothers to Queen Elizabeth), Two Bishops, Sir William Brandon, Lords, Attendants, Citizens, Aldermen, Councillors, Soldiers</persName>
+          </person>
+          <person xml:id="ATTENDANTS.RICHMOND.0.1_R3">
+            <persName>Guards, Tressel, Berkeley, Halberds, Gentlemen, Anthony Woodeville and Lord Scales (brothers to Queen Elizabeth), Two Bishops, Sir William Brandon, Lords, Attendants, Citizens, Aldermen, Councillors, Soldiers</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.3_R3">
+            <persName>MESSENGERS.X.3_R3</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/romeo-and-juliet.xml
+++ b/tei/romeo-and-juliet.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,125 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Chorus_Rom"><persName>Chorus</persName></person><person xml:id="SERVANTS.CAPULET.Sampson_Rom"><persName>Sampson</persName></person><person xml:id="SERVANTS.CAPULET.Gregory_Rom"><persName>Gregory</persName></person><person xml:id="SERVANTS.MONTAGUE.Abram_Rom"><persName>Abram</persName></person><person xml:id="Benvolio_Rom"><persName>Benvolio</persName></person><person xml:id="Tybalt_Rom"><persName>Tybalt</persName></person><person xml:id="CITIZENS_Rom"><persName>Three or four Citizens</persName></person><person xml:id="Capulet_Rom"><persName>Capulet</persName></person><person xml:id="LadyCapulet_Rom"><persName>Lady Capulet</persName></person><person xml:id="Montague_Rom"><persName>Montague</persName></person><person xml:id="LadyMontague_Rom"><persName>Lady Montague</persName></person><person xml:id="PrinceEscalus_Rom"><persName>Escalus</persName></person><person xml:id="Romeo_Rom"><persName>Romeo</persName></person><person xml:id="Paris_Rom"><persName>Paris</persName></person><person xml:id="SERVANTS.CAPULET.X.1_Rom"><persName>SERVANTS.CAPULET.X.1_Rom</persName></person><person xml:id="Nurse_Rom"><persName>Nurse</persName></person><person xml:id="Juliet_Rom"><persName>Juliet</persName></person><person xml:id="SERVANTS.CAPULET.X.2_Rom"><persName>SERVANTS.CAPULET.X.2_Rom</persName></person><person xml:id="Mercutio_Rom"><persName>Mercutio</persName></person><person xml:id="SERVANTS.CAPULET.0.1_Rom"><persName>SERVANTS.CAPULET.0.1_Rom</persName></person><person xml:id="SERVANTS.CAPULET.0.2_Rom"><persName>SERVANTS.CAPULET.0.2_Rom</persName></person><person xml:id="SERVANTS.CAPULET.0.3_Rom"><persName>SERVANTS.CAPULET.0.3_Rom</persName></person><person xml:id="Cousin_Rom"><persName>Cousin_Rom</persName></person><person xml:id="SERVANTS.CAPULET.0_Rom"><persName>SERVANTS.CAPULET.0_Rom</persName></person><person xml:id="FriarLawrence_Rom"><persName>Friar Lawrence</persName></person><person xml:id="SERVANTS.CAPULET.Peter_Rom"><persName>Peter</persName></person><person xml:id="Petruchio_Rom"><persName>Petruchio</persName></person><person xml:id="CITIZENS.0.1_Rom"><persName>CITIZENS.0.1_Rom</persName></person><person xml:id="MUSICIANS.0.1_Rom"><persName>MUSICIANS.0.1_Rom</persName></person><person xml:id="MUSICIANS.0.2_Rom"><persName>MUSICIANS.0.2_Rom</persName></person><person xml:id="MUSICIANS.0.3_Rom"><persName>MUSICIANS.0.3_Rom</persName></person><person xml:id="SERVANTS.MONTAGUE.Balthasar_Rom"><persName>Balthasar</persName></person><person xml:id="Apothecary_Rom"><persName>Apothecary</persName></person><person xml:id="FriarJohn_Rom"><persName>Friar John</persName></person><person xml:id="SERVANTS.PARIS.1_Rom"><persName>SERVANTS.PARIS.1_Rom</persName></person><person xml:id="WATCHMEN.0.1_Rom"><persName>WATCHMEN.0.1_Rom</persName></person><person xml:id="WATCHMEN.0.2_Rom"><persName>WATCHMEN.0.2_Rom</persName></person><person xml:id="WATCHMEN.0.3_Rom"><persName>WATCHMEN.0.3_Rom</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Chorus_Rom">
+            <persName>Chorus</persName>
+          </person>
+          <person xml:id="SERVANTS.CAPULET.Sampson_Rom">
+            <persName>Sampson</persName>
+          </person>
+          <person xml:id="SERVANTS.CAPULET.Gregory_Rom">
+            <persName>Gregory</persName>
+          </person>
+          <person xml:id="SERVANTS.MONTAGUE.Abram_Rom">
+            <persName>Abram</persName>
+          </person>
+          <person xml:id="Benvolio_Rom">
+            <persName>Benvolio</persName>
+          </person>
+          <person xml:id="Tybalt_Rom">
+            <persName>Tybalt</persName>
+          </person>
+          <person xml:id="CITIZENS_Rom">
+            <persName>Three or four Citizens</persName>
+          </person>
+          <person xml:id="Capulet_Rom">
+            <persName>Capulet</persName>
+          </person>
+          <person xml:id="LadyCapulet_Rom">
+            <persName>Lady Capulet</persName>
+          </person>
+          <person xml:id="Montague_Rom">
+            <persName>Montague</persName>
+          </person>
+          <person xml:id="LadyMontague_Rom">
+            <persName>Lady Montague</persName>
+          </person>
+          <person xml:id="PrinceEscalus_Rom">
+            <persName>Escalus</persName>
+          </person>
+          <person xml:id="Romeo_Rom">
+            <persName>Romeo</persName>
+          </person>
+          <person xml:id="Paris_Rom">
+            <persName>Paris</persName>
+          </person>
+          <person xml:id="SERVANTS.CAPULET.X.1_Rom">
+            <persName>SERVANTS.CAPULET.X.1_Rom</persName>
+          </person>
+          <person xml:id="Nurse_Rom">
+            <persName>Nurse</persName>
+          </person>
+          <person xml:id="Juliet_Rom">
+            <persName>Juliet</persName>
+          </person>
+          <person xml:id="SERVANTS.CAPULET.X.2_Rom">
+            <persName>SERVANTS.CAPULET.X.2_Rom</persName>
+          </person>
+          <person xml:id="Mercutio_Rom">
+            <persName>Mercutio</persName>
+          </person>
+          <person xml:id="SERVANTS.CAPULET.0.1_Rom">
+            <persName>SERVANTS.CAPULET.0.1_Rom</persName>
+          </person>
+          <person xml:id="SERVANTS.CAPULET.0.2_Rom">
+            <persName>SERVANTS.CAPULET.0.2_Rom</persName>
+          </person>
+          <person xml:id="SERVANTS.CAPULET.0.3_Rom">
+            <persName>SERVANTS.CAPULET.0.3_Rom</persName>
+          </person>
+          <person xml:id="Cousin_Rom">
+            <persName>Cousin_Rom</persName>
+          </person>
+          <person xml:id="SERVANTS.CAPULET.0_Rom">
+            <persName>SERVANTS.CAPULET.0_Rom</persName>
+          </person>
+          <person xml:id="FriarLawrence_Rom">
+            <persName>Friar Lawrence</persName>
+          </person>
+          <person xml:id="SERVANTS.CAPULET.Peter_Rom">
+            <persName>Peter</persName>
+          </person>
+          <person xml:id="Petruchio_Rom">
+            <persName>Petruchio</persName>
+          </person>
+          <person xml:id="CITIZENS.0.1_Rom">
+            <persName>CITIZENS.0.1_Rom</persName>
+          </person>
+          <person xml:id="MUSICIANS.0.1_Rom">
+            <persName>MUSICIANS.0.1_Rom</persName>
+          </person>
+          <person xml:id="MUSICIANS.0.2_Rom">
+            <persName>MUSICIANS.0.2_Rom</persName>
+          </person>
+          <person xml:id="MUSICIANS.0.3_Rom">
+            <persName>MUSICIANS.0.3_Rom</persName>
+          </person>
+          <person xml:id="SERVANTS.MONTAGUE.Balthasar_Rom">
+            <persName>Balthasar</persName>
+          </person>
+          <person xml:id="Apothecary_Rom">
+            <persName>Apothecary</persName>
+          </person>
+          <person xml:id="FriarJohn_Rom">
+            <persName>Friar John</persName>
+          </person>
+          <person xml:id="SERVANTS.PARIS.1_Rom">
+            <persName>SERVANTS.PARIS.1_Rom</persName>
+          </person>
+          <person xml:id="WATCHMEN.0.1_Rom">
+            <persName>WATCHMEN.0.1_Rom</persName>
+          </person>
+          <person xml:id="WATCHMEN.0.2_Rom">
+            <persName>WATCHMEN.0.2_Rom</persName>
+          </person>
+          <person xml:id="WATCHMEN.0.3_Rom">
+            <persName>WATCHMEN.0.3_Rom</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/romeo-and-juliet.xml
+++ b/tei/romeo-and-juliet.xml
@@ -88,118 +88,118 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Chorus_Rom">
-            <persName>Chorus</persName>
-          </person>
-          <person xml:id="SERVANTS.CAPULET.Sampson_Rom">
+          <personGrp xml:id="Chorus_Rom" sex="UNKNOWN">
+            <name>Chorus</name>
+          </personGrp>
+          <person xml:id="SERVANTS.CAPULET.Sampson_Rom" sex="MALE">
             <persName>Sampson</persName>
           </person>
-          <person xml:id="SERVANTS.CAPULET.Gregory_Rom">
+          <person xml:id="SERVANTS.CAPULET.Gregory_Rom" sex="MALE">
             <persName>Gregory</persName>
           </person>
-          <person xml:id="SERVANTS.MONTAGUE.Abram_Rom">
+          <person xml:id="SERVANTS.MONTAGUE.Abram_Rom" sex="MALE">
             <persName>Abram</persName>
           </person>
-          <person xml:id="Benvolio_Rom">
+          <person xml:id="Benvolio_Rom" sex="MALE">
             <persName>Benvolio</persName>
           </person>
-          <person xml:id="Tybalt_Rom">
+          <person xml:id="Tybalt_Rom" sex="FEMALE">
             <persName>Tybalt</persName>
           </person>
-          <person xml:id="CITIZENS_Rom">
-            <persName>Three or four Citizens</persName>
-          </person>
-          <person xml:id="Capulet_Rom">
+          <personGrp xml:id="CITIZENS_Rom" sex="UNKNOWN">
+            <name>Three or four Citizens</name>
+          </personGrp>
+          <person xml:id="Capulet_Rom" sex="MALE">
             <persName>Capulet</persName>
           </person>
-          <person xml:id="LadyCapulet_Rom">
+          <person xml:id="LadyCapulet_Rom" sex="FEMALE">
             <persName>Lady Capulet</persName>
           </person>
-          <person xml:id="Montague_Rom">
+          <person xml:id="Montague_Rom" sex="MALE">
             <persName>Montague</persName>
           </person>
-          <person xml:id="LadyMontague_Rom">
+          <person xml:id="LadyMontague_Rom" sex="FEMALE">
             <persName>Lady Montague</persName>
           </person>
-          <person xml:id="PrinceEscalus_Rom">
+          <person xml:id="PrinceEscalus_Rom" sex="MALE">
             <persName>Escalus</persName>
           </person>
-          <person xml:id="Romeo_Rom">
+          <person xml:id="Romeo_Rom" sex="MALE">
             <persName>Romeo</persName>
           </person>
-          <person xml:id="Paris_Rom">
+          <person xml:id="Paris_Rom" sex="MALE">
             <persName>Paris</persName>
           </person>
-          <person xml:id="SERVANTS.CAPULET.X.1_Rom">
-            <persName>SERVANTS.CAPULET.X.1_Rom</persName>
-          </person>
-          <person xml:id="Nurse_Rom">
+          <personGrp xml:id="SERVANTS.CAPULET.X.1_Rom" sex="UNKNOWN">
+            <name>SERVANTS.CAPULET.X.1_Rom</name>
+          </personGrp>
+          <person xml:id="Nurse_Rom" sex="FEMALE">
             <persName>Nurse</persName>
           </person>
-          <person xml:id="Juliet_Rom">
+          <person xml:id="Juliet_Rom" sex="FEMALE">
             <persName>Juliet</persName>
           </person>
-          <person xml:id="SERVANTS.CAPULET.X.2_Rom">
-            <persName>SERVANTS.CAPULET.X.2_Rom</persName>
-          </person>
-          <person xml:id="Mercutio_Rom">
+          <personGrp xml:id="SERVANTS.CAPULET.X.2_Rom" sex="UNKNOWN">
+            <name>SERVANTS.CAPULET.X.2_Rom</name>
+          </personGrp>
+          <person xml:id="Mercutio_Rom" sex="MALE">
             <persName>Mercutio</persName>
           </person>
-          <person xml:id="SERVANTS.CAPULET.0.1_Rom">
+          <person xml:id="SERVANTS.CAPULET.0.1_Rom" sex="MALE">
             <persName>SERVANTS.CAPULET.0.1_Rom</persName>
           </person>
-          <person xml:id="SERVANTS.CAPULET.0.2_Rom">
+          <person xml:id="SERVANTS.CAPULET.0.2_Rom" sex="MALE">
             <persName>SERVANTS.CAPULET.0.2_Rom</persName>
           </person>
-          <person xml:id="SERVANTS.CAPULET.0.3_Rom">
+          <person xml:id="SERVANTS.CAPULET.0.3_Rom" sex="MALE">
             <persName>SERVANTS.CAPULET.0.3_Rom</persName>
           </person>
-          <person xml:id="Cousin_Rom">
+          <person xml:id="Cousin_Rom" sex="MALE">
             <persName>Cousin_Rom</persName>
           </person>
-          <person xml:id="SERVANTS.CAPULET.0_Rom">
+          <person xml:id="SERVANTS.CAPULET.0_Rom" sex="MALE">
             <persName>SERVANTS.CAPULET.0_Rom</persName>
           </person>
-          <person xml:id="FriarLawrence_Rom">
+          <person xml:id="FriarLawrence_Rom" sex="MALE">
             <persName>Friar Lawrence</persName>
           </person>
-          <person xml:id="SERVANTS.CAPULET.Peter_Rom">
+          <person xml:id="SERVANTS.CAPULET.Peter_Rom" sex="MALE">
             <persName>Peter</persName>
           </person>
-          <person xml:id="Petruchio_Rom">
+          <person xml:id="Petruchio_Rom" sex="MALE">
             <persName>Petruchio</persName>
           </person>
-          <person xml:id="CITIZENS.0.1_Rom">
+          <person xml:id="CITIZENS.0.1_Rom" sex="MALE">
             <persName>CITIZENS.0.1_Rom</persName>
           </person>
-          <person xml:id="MUSICIANS.0.1_Rom">
+          <person xml:id="MUSICIANS.0.1_Rom" sex="MALE">
             <persName>MUSICIANS.0.1_Rom</persName>
           </person>
-          <person xml:id="MUSICIANS.0.2_Rom">
+          <person xml:id="MUSICIANS.0.2_Rom" sex="MALE">
             <persName>MUSICIANS.0.2_Rom</persName>
           </person>
-          <person xml:id="MUSICIANS.0.3_Rom">
+          <person xml:id="MUSICIANS.0.3_Rom" sex="MALE">
             <persName>MUSICIANS.0.3_Rom</persName>
           </person>
-          <person xml:id="SERVANTS.MONTAGUE.Balthasar_Rom">
+          <person xml:id="SERVANTS.MONTAGUE.Balthasar_Rom" sex="MALE">
             <persName>Balthasar</persName>
           </person>
-          <person xml:id="Apothecary_Rom">
+          <person xml:id="Apothecary_Rom" sex="MALE">
             <persName>Apothecary</persName>
           </person>
-          <person xml:id="FriarJohn_Rom">
+          <person xml:id="FriarJohn_Rom" sex="MALE">
             <persName>Friar John</persName>
           </person>
-          <person xml:id="SERVANTS.PARIS.1_Rom">
-            <persName>SERVANTS.PARIS.1_Rom</persName>
-          </person>
-          <person xml:id="WATCHMEN.0.1_Rom">
+          <personGrp xml:id="SERVANTS.PARIS.1_Rom" sex="UNKNOWN">
+            <name>SERVANTS.PARIS.1_Rom</name>
+          </personGrp>
+          <person xml:id="WATCHMEN.0.1_Rom" sex="MALE">
             <persName>WATCHMEN.0.1_Rom</persName>
           </person>
-          <person xml:id="WATCHMEN.0.2_Rom">
+          <person xml:id="WATCHMEN.0.2_Rom" sex="MALE">
             <persName>WATCHMEN.0.2_Rom</persName>
           </person>
-          <person xml:id="WATCHMEN.0.3_Rom">
+          <person xml:id="WATCHMEN.0.3_Rom" sex="MALE">
             <persName>WATCHMEN.0.3_Rom</persName>
           </person>
         </listPerson>

--- a/tei/the-comedy-of-errors.xml
+++ b/tei/the-comedy-of-errors.xml
@@ -88,61 +88,61 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Egeon_Err">
+          <person xml:id="Egeon_Err" sex="MALE">
             <persName>Egeon</persName>
           </person>
-          <person xml:id="Duke_Err">
+          <person xml:id="Duke_Err" sex="MALE">
             <persName>Duke</persName>
           </person>
-          <person xml:id="OFFICERS.Jailer_Err">
+          <person xml:id="OFFICERS.Jailer_Err" sex="MALE">
             <persName>Officer</persName>
           </person>
-          <person xml:id="Merchant1_Err">
+          <person xml:id="Merchant1_Err" sex="MALE">
             <persName>First Merchant</persName>
           </person>
-          <person xml:id="AntipholusOfSyracuse_Err">
+          <person xml:id="AntipholusOfSyracuse_Err" sex="MALE">
             <persName>Antipholus of Syracuse</persName>
           </person>
-          <person xml:id="DromioOfSyracuse_Err">
+          <person xml:id="DromioOfSyracuse_Err" sex="MALE">
             <persName>Dromio of Syracuse</persName>
           </person>
-          <person xml:id="DromioOfEphesus_Err">
+          <person xml:id="DromioOfEphesus_Err" sex="MALE">
             <persName>Dromio of Ephesus</persName>
           </person>
-          <person xml:id="Adriana_Err">
+          <person xml:id="Adriana_Err" sex="FEMALE">
             <persName>Adriana</persName>
           </person>
-          <person xml:id="Luciana_Err">
+          <person xml:id="Luciana_Err" sex="FEMALE">
             <persName>Luciana</persName>
           </person>
-          <person xml:id="AntipholusOfEphesus_Err">
+          <person xml:id="AntipholusOfEphesus_Err" sex="MALE">
             <persName>Antipholus of Ephesus</persName>
           </person>
-          <person xml:id="Balthasar_Err">
+          <person xml:id="Balthasar_Err" sex="MALE">
             <persName>Balthasar</persName>
           </person>
-          <person xml:id="Luce_Err">
+          <person xml:id="Luce_Err" sex="FEMALE">
             <persName>Luce</persName>
           </person>
-          <person xml:id="Angelo_Err">
+          <person xml:id="Angelo_Err" sex="MALE">
             <persName>Angelo</persName>
           </person>
-          <person xml:id="Merchant2_Err">
+          <person xml:id="Merchant2_Err" sex="MALE">
             <persName>Second Merchant</persName>
           </person>
-          <person xml:id="OFFICERS.X_Err">
-            <persName>Attendants, Servants to Pinch, Headsman, Officers</persName>
-          </person>
-          <person xml:id="Courtesan_Err">
+          <personGrp xml:id="OFFICERS.X_Err" sex="UNKNOWN">
+            <name>Attendants, Servants to Pinch, Headsman, Officers</name>
+          </personGrp>
+          <person xml:id="Courtesan_Err" sex="FEMALE">
             <persName>Courtesan</persName>
           </person>
-          <person xml:id="Pinch_Err">
+          <person xml:id="Pinch_Err" sex="MALE">
             <persName>Dr. Pinch</persName>
           </person>
-          <person xml:id="Abbess_Err">
+          <person xml:id="Abbess_Err" sex="FEMALE">
             <persName>Lady Abbess</persName>
           </person>
-          <person xml:id="Messenger_Err">
+          <person xml:id="Messenger_Err" sex="MALE">
             <persName>Messenger</persName>
           </person>
         </listPerson>

--- a/tei/the-comedy-of-errors.xml
+++ b/tei/the-comedy-of-errors.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,68 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Egeon_Err"><persName>Egeon</persName></person><person xml:id="Duke_Err"><persName>Duke</persName></person><person xml:id="OFFICERS.Jailer_Err"><persName>Officer</persName></person><person xml:id="Merchant1_Err"><persName>First Merchant</persName></person><person xml:id="AntipholusOfSyracuse_Err"><persName>Antipholus of Syracuse</persName></person><person xml:id="DromioOfSyracuse_Err"><persName>Dromio of Syracuse</persName></person><person xml:id="DromioOfEphesus_Err"><persName>Dromio of Ephesus</persName></person><person xml:id="Adriana_Err"><persName>Adriana</persName></person><person xml:id="Luciana_Err"><persName>Luciana</persName></person><person xml:id="AntipholusOfEphesus_Err"><persName>Antipholus of Ephesus</persName></person><person xml:id="Balthasar_Err"><persName>Balthasar</persName></person><person xml:id="Luce_Err"><persName>Luce</persName></person><person xml:id="Angelo_Err"><persName>Angelo</persName></person><person xml:id="Merchant2_Err"><persName>Second Merchant</persName></person><person xml:id="OFFICERS.X_Err"><persName>Attendants, Servants to Pinch, Headsman, Officers</persName></person><person xml:id="Courtesan_Err"><persName>Courtesan</persName></person><person xml:id="Pinch_Err"><persName>Dr. Pinch</persName></person><person xml:id="Abbess_Err"><persName>Lady Abbess</persName></person><person xml:id="Messenger_Err"><persName>Messenger</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Egeon_Err">
+            <persName>Egeon</persName>
+          </person>
+          <person xml:id="Duke_Err">
+            <persName>Duke</persName>
+          </person>
+          <person xml:id="OFFICERS.Jailer_Err">
+            <persName>Officer</persName>
+          </person>
+          <person xml:id="Merchant1_Err">
+            <persName>First Merchant</persName>
+          </person>
+          <person xml:id="AntipholusOfSyracuse_Err">
+            <persName>Antipholus of Syracuse</persName>
+          </person>
+          <person xml:id="DromioOfSyracuse_Err">
+            <persName>Dromio of Syracuse</persName>
+          </person>
+          <person xml:id="DromioOfEphesus_Err">
+            <persName>Dromio of Ephesus</persName>
+          </person>
+          <person xml:id="Adriana_Err">
+            <persName>Adriana</persName>
+          </person>
+          <person xml:id="Luciana_Err">
+            <persName>Luciana</persName>
+          </person>
+          <person xml:id="AntipholusOfEphesus_Err">
+            <persName>Antipholus of Ephesus</persName>
+          </person>
+          <person xml:id="Balthasar_Err">
+            <persName>Balthasar</persName>
+          </person>
+          <person xml:id="Luce_Err">
+            <persName>Luce</persName>
+          </person>
+          <person xml:id="Angelo_Err">
+            <persName>Angelo</persName>
+          </person>
+          <person xml:id="Merchant2_Err">
+            <persName>Second Merchant</persName>
+          </person>
+          <person xml:id="OFFICERS.X_Err">
+            <persName>Attendants, Servants to Pinch, Headsman, Officers</persName>
+          </person>
+          <person xml:id="Courtesan_Err">
+            <persName>Courtesan</persName>
+          </person>
+          <person xml:id="Pinch_Err">
+            <persName>Dr. Pinch</persName>
+          </person>
+          <person xml:id="Abbess_Err">
+            <persName>Lady Abbess</persName>
+          </person>
+          <person xml:id="Messenger_Err">
+            <persName>Messenger</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/the-merchant-of-venice.xml
+++ b/tei/the-merchant-of-venice.xml
@@ -88,76 +88,76 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Antonio_MV">
+          <person xml:id="Antonio_MV" sex="MALE">
             <persName>Antonio</persName>
           </person>
-          <person xml:id="Salarino_MV">
+          <person xml:id="Salarino_MV" sex="MALE">
             <persName>Salarino</persName>
           </person>
-          <person xml:id="Solanio_MV">
+          <person xml:id="Solanio_MV" sex="MALE">
             <persName>Solanio</persName>
           </person>
-          <person xml:id="Bassanio_MV">
+          <person xml:id="Bassanio_MV" sex="MALE">
             <persName>Bassanio</persName>
           </person>
-          <person xml:id="Lorenzo_MV">
+          <person xml:id="Lorenzo_MV" sex="MALE">
             <persName>Lorenzo</persName>
           </person>
-          <person xml:id="Gratiano_MV">
+          <person xml:id="Gratiano_MV" sex="MALE">
             <persName>Gratiano</persName>
           </person>
-          <person xml:id="Portia_MV">
+          <person xml:id="Portia_MV" sex="FEMALE">
             <persName>Portia</persName>
           </person>
-          <person xml:id="Nerissa_MV">
+          <person xml:id="Nerissa_MV" sex="FEMALE">
             <persName>Nerissa</persName>
           </person>
-          <person xml:id="SERVANTS.1_MV">
+          <person xml:id="SERVANTS.1_MV" sex="MALE">
             <persName>SERVANTS.1_MV</persName>
           </person>
-          <person xml:id="Shylock_MV">
+          <person xml:id="Shylock_MV" sex="MALE">
             <persName>Shylock</persName>
           </person>
-          <person xml:id="Morocco_MV">
+          <person xml:id="Morocco_MV" sex="MALE">
             <persName>Morocco</persName>
           </person>
-          <person xml:id="LanceletGobbo_MV">
+          <person xml:id="LanceletGobbo_MV" sex="MALE">
             <persName>Lancelet Gobbo</persName>
           </person>
-          <person xml:id="OldGobbo_MV">
+          <person xml:id="OldGobbo_MV" sex="MALE">
             <persName>Old Gobbo</persName>
           </person>
-          <person xml:id="ATTENDANTS.BASSANIO.Leonardo_MV">
+          <person xml:id="ATTENDANTS.BASSANIO.Leonardo_MV" sex="MALE">
             <persName>Leonardo</persName>
           </person>
-          <person xml:id="Jessica_MV">
+          <person xml:id="Jessica_MV" sex="FEMALE">
             <persName>Jessica</persName>
           </person>
-          <person xml:id="Arragon_MV">
+          <person xml:id="Arragon_MV" sex="MALE">
             <persName>Arragon</persName>
           </person>
-          <person xml:id="Messenger_MV">
+          <person xml:id="Messenger_MV" sex="MALE">
             <persName>Messenger</persName>
           </person>
-          <person xml:id="SERVANTS.2_MV">
+          <person xml:id="SERVANTS.2_MV" sex="MALE">
             <persName>SERVANTS.2_MV</persName>
           </person>
-          <person xml:id="Tubal_MV">
+          <person xml:id="Tubal_MV" sex="MALE">
             <persName>Tubal</persName>
           </person>
-          <person xml:id="MUSICIANS_MV">
-            <persName>Musicians</persName>
-          </person>
-          <person xml:id="Salerio_MV">
+          <personGrp xml:id="MUSICIANS_MV" sex="UNKNOWN">
+            <name>Musicians</name>
+          </personGrp>
+          <person xml:id="Salerio_MV" sex="MALE">
             <persName>Salerio</persName>
           </person>
-          <person xml:id="ATTENDANTS.PORTIA.Balthazar_MV">
+          <person xml:id="ATTENDANTS.PORTIA.Balthazar_MV" sex="MALE">
             <persName>Balthazar</persName>
           </person>
-          <person xml:id="Duke_MV">
+          <person xml:id="Duke_MV" sex="MALE">
             <persName>Duke_MV</persName>
           </person>
-          <person xml:id="ATTENDANTS.PORTIA.Stephano_MV">
+          <person xml:id="ATTENDANTS.PORTIA.Stephano_MV" sex="MALE">
             <persName>Stephano</persName>
           </person>
         </listPerson>

--- a/tei/the-merchant-of-venice.xml
+++ b/tei/the-merchant-of-venice.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,83 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Antonio_MV"><persName>Antonio</persName></person><person xml:id="Salarino_MV"><persName>Salarino</persName></person><person xml:id="Solanio_MV"><persName>Solanio</persName></person><person xml:id="Bassanio_MV"><persName>Bassanio</persName></person><person xml:id="Lorenzo_MV"><persName>Lorenzo</persName></person><person xml:id="Gratiano_MV"><persName>Gratiano</persName></person><person xml:id="Portia_MV"><persName>Portia</persName></person><person xml:id="Nerissa_MV"><persName>Nerissa</persName></person><person xml:id="SERVANTS.1_MV"><persName>SERVANTS.1_MV</persName></person><person xml:id="Shylock_MV"><persName>Shylock</persName></person><person xml:id="Morocco_MV"><persName>Morocco</persName></person><person xml:id="LanceletGobbo_MV"><persName>Lancelet Gobbo</persName></person><person xml:id="OldGobbo_MV"><persName>Old Gobbo</persName></person><person xml:id="ATTENDANTS.BASSANIO.Leonardo_MV"><persName>Leonardo</persName></person><person xml:id="Jessica_MV"><persName>Jessica</persName></person><person xml:id="Arragon_MV"><persName>Arragon</persName></person><person xml:id="Messenger_MV"><persName>Messenger</persName></person><person xml:id="SERVANTS.2_MV"><persName>SERVANTS.2_MV</persName></person><person xml:id="Tubal_MV"><persName>Tubal</persName></person><person xml:id="MUSICIANS_MV"><persName>Musicians</persName></person><person xml:id="Salerio_MV"><persName>Salerio</persName></person><person xml:id="ATTENDANTS.PORTIA.Balthazar_MV"><persName>Balthazar</persName></person><person xml:id="Duke_MV"><persName>Duke_MV</persName></person><person xml:id="ATTENDANTS.PORTIA.Stephano_MV"><persName>Stephano</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Antonio_MV">
+            <persName>Antonio</persName>
+          </person>
+          <person xml:id="Salarino_MV">
+            <persName>Salarino</persName>
+          </person>
+          <person xml:id="Solanio_MV">
+            <persName>Solanio</persName>
+          </person>
+          <person xml:id="Bassanio_MV">
+            <persName>Bassanio</persName>
+          </person>
+          <person xml:id="Lorenzo_MV">
+            <persName>Lorenzo</persName>
+          </person>
+          <person xml:id="Gratiano_MV">
+            <persName>Gratiano</persName>
+          </person>
+          <person xml:id="Portia_MV">
+            <persName>Portia</persName>
+          </person>
+          <person xml:id="Nerissa_MV">
+            <persName>Nerissa</persName>
+          </person>
+          <person xml:id="SERVANTS.1_MV">
+            <persName>SERVANTS.1_MV</persName>
+          </person>
+          <person xml:id="Shylock_MV">
+            <persName>Shylock</persName>
+          </person>
+          <person xml:id="Morocco_MV">
+            <persName>Morocco</persName>
+          </person>
+          <person xml:id="LanceletGobbo_MV">
+            <persName>Lancelet Gobbo</persName>
+          </person>
+          <person xml:id="OldGobbo_MV">
+            <persName>Old Gobbo</persName>
+          </person>
+          <person xml:id="ATTENDANTS.BASSANIO.Leonardo_MV">
+            <persName>Leonardo</persName>
+          </person>
+          <person xml:id="Jessica_MV">
+            <persName>Jessica</persName>
+          </person>
+          <person xml:id="Arragon_MV">
+            <persName>Arragon</persName>
+          </person>
+          <person xml:id="Messenger_MV">
+            <persName>Messenger</persName>
+          </person>
+          <person xml:id="SERVANTS.2_MV">
+            <persName>SERVANTS.2_MV</persName>
+          </person>
+          <person xml:id="Tubal_MV">
+            <persName>Tubal</persName>
+          </person>
+          <person xml:id="MUSICIANS_MV">
+            <persName>Musicians</persName>
+          </person>
+          <person xml:id="Salerio_MV">
+            <persName>Salerio</persName>
+          </person>
+          <person xml:id="ATTENDANTS.PORTIA.Balthazar_MV">
+            <persName>Balthazar</persName>
+          </person>
+          <person xml:id="Duke_MV">
+            <persName>Duke_MV</persName>
+          </person>
+          <person xml:id="ATTENDANTS.PORTIA.Stephano_MV">
+            <persName>Stephano</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/the-merry-wives-of-windsor.xml
+++ b/tei/the-merry-wives-of-windsor.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,80 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Shallow_2H4"><persName>Shallow</persName></person><person xml:id="Slender_Wiv"><persName>Slender</persName></person><person xml:id="HughEvans_Wiv"><persName>Sir Hugh</persName></person><person xml:id="MasterPage_Wiv"><persName>Page</persName></person><person xml:id="Falstaff_1H4"><persName>Falstaff</persName></person><person xml:id="Bardolph_1H4"><persName>Bardolph</persName></person><person xml:id="Pistol_2H4"><persName>Pistol</persName></person><person xml:id="Nym_H5"><persName>Nym</persName></person><person xml:id="Simple_Wiv"><persName>Simple</persName></person><person xml:id="AnnePage_Wiv"><persName>Anne</persName></person><person xml:id="Host_Wiv"><persName>Host</persName></person><person xml:id="MistressQuickly_1H4"><persName>Mistress Quickly</persName></person><person xml:id="Rugby_Wiv"><persName>John Rugby</persName></person><person xml:id="DoctorCaius_Wiv"><persName>Doctor Caius</persName></person><person xml:id="Fenton_Wiv"><persName>Fenton</persName></person><person xml:id="MistressPage_Wiv"><persName>Mistress Page</persName></person><person xml:id="MistressFord_Wiv"><persName>Mistress Ford</persName></person><person xml:id="MasterFord_Wiv"><persName>Ford</persName></person><person xml:id="Robin_Wiv"><persName>Robin</persName></person><person xml:id="Robert_Wiv"><persName>Robert</persName></person><person xml:id="John_Wiv"><persName>John</persName></person><person xml:id="WilliamPage_Wiv"><persName>William</persName></person><person xml:id="BOYS_Wiv"><persName>Windsor Children, disguised as fairies</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Shallow_2H4">
+            <persName>Shallow</persName>
+          </person>
+          <person xml:id="Slender_Wiv">
+            <persName>Slender</persName>
+          </person>
+          <person xml:id="HughEvans_Wiv">
+            <persName>Sir Hugh</persName>
+          </person>
+          <person xml:id="MasterPage_Wiv">
+            <persName>Page</persName>
+          </person>
+          <person xml:id="Falstaff_1H4">
+            <persName>Falstaff</persName>
+          </person>
+          <person xml:id="Bardolph_1H4">
+            <persName>Bardolph</persName>
+          </person>
+          <person xml:id="Pistol_2H4">
+            <persName>Pistol</persName>
+          </person>
+          <person xml:id="Nym_H5">
+            <persName>Nym</persName>
+          </person>
+          <person xml:id="Simple_Wiv">
+            <persName>Simple</persName>
+          </person>
+          <person xml:id="AnnePage_Wiv">
+            <persName>Anne</persName>
+          </person>
+          <person xml:id="Host_Wiv">
+            <persName>Host</persName>
+          </person>
+          <person xml:id="MistressQuickly_1H4">
+            <persName>Mistress Quickly</persName>
+          </person>
+          <person xml:id="Rugby_Wiv">
+            <persName>John Rugby</persName>
+          </person>
+          <person xml:id="DoctorCaius_Wiv">
+            <persName>Doctor Caius</persName>
+          </person>
+          <person xml:id="Fenton_Wiv">
+            <persName>Fenton</persName>
+          </person>
+          <person xml:id="MistressPage_Wiv">
+            <persName>Mistress Page</persName>
+          </person>
+          <person xml:id="MistressFord_Wiv">
+            <persName>Mistress Ford</persName>
+          </person>
+          <person xml:id="MasterFord_Wiv">
+            <persName>Ford</persName>
+          </person>
+          <person xml:id="Robin_Wiv">
+            <persName>Robin</persName>
+          </person>
+          <person xml:id="Robert_Wiv">
+            <persName>Robert</persName>
+          </person>
+          <person xml:id="John_Wiv">
+            <persName>John</persName>
+          </person>
+          <person xml:id="WilliamPage_Wiv">
+            <persName>William</persName>
+          </person>
+          <person xml:id="BOYS_Wiv">
+            <persName>Windsor Children, disguised as fairies</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/the-merry-wives-of-windsor.xml
+++ b/tei/the-merry-wives-of-windsor.xml
@@ -88,75 +88,75 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Shallow_2H4">
+          <person xml:id="Shallow_2H4" sex="MALE">
             <persName>Shallow</persName>
           </person>
-          <person xml:id="Slender_Wiv">
+          <person xml:id="Slender_Wiv" sex="MALE">
             <persName>Slender</persName>
           </person>
-          <person xml:id="HughEvans_Wiv">
+          <person xml:id="HughEvans_Wiv" sex="MALE">
             <persName>Sir Hugh</persName>
           </person>
-          <person xml:id="MasterPage_Wiv">
+          <person xml:id="MasterPage_Wiv" sex="MALE">
             <persName>Page</persName>
           </person>
-          <person xml:id="Falstaff_1H4">
+          <person xml:id="Falstaff_1H4" sex="MALE">
             <persName>Falstaff</persName>
           </person>
-          <person xml:id="Bardolph_1H4">
+          <person xml:id="Bardolph_1H4" sex="MALE">
             <persName>Bardolph</persName>
           </person>
-          <person xml:id="Pistol_2H4">
+          <person xml:id="Pistol_2H4" sex="MALE">
             <persName>Pistol</persName>
           </person>
-          <person xml:id="Nym_H5">
+          <person xml:id="Nym_H5" sex="MALE">
             <persName>Nym</persName>
           </person>
-          <person xml:id="Simple_Wiv">
+          <person xml:id="Simple_Wiv" sex="MALE">
             <persName>Simple</persName>
           </person>
-          <person xml:id="AnnePage_Wiv">
+          <person xml:id="AnnePage_Wiv" sex="FEMALE">
             <persName>Anne</persName>
           </person>
-          <person xml:id="Host_Wiv">
+          <person xml:id="Host_Wiv" sex="MALE">
             <persName>Host</persName>
           </person>
-          <person xml:id="MistressQuickly_1H4">
+          <person xml:id="MistressQuickly_1H4" sex="FEMALE">
             <persName>Mistress Quickly</persName>
           </person>
-          <person xml:id="Rugby_Wiv">
+          <person xml:id="Rugby_Wiv" sex="MALE">
             <persName>John Rugby</persName>
           </person>
-          <person xml:id="DoctorCaius_Wiv">
+          <person xml:id="DoctorCaius_Wiv" sex="MALE">
             <persName>Doctor Caius</persName>
           </person>
-          <person xml:id="Fenton_Wiv">
+          <person xml:id="Fenton_Wiv" sex="MALE">
             <persName>Fenton</persName>
           </person>
-          <person xml:id="MistressPage_Wiv">
+          <person xml:id="MistressPage_Wiv" sex="FEMALE">
             <persName>Mistress Page</persName>
           </person>
-          <person xml:id="MistressFord_Wiv">
+          <person xml:id="MistressFord_Wiv" sex="FEMALE">
             <persName>Mistress Ford</persName>
           </person>
-          <person xml:id="MasterFord_Wiv">
+          <person xml:id="MasterFord_Wiv" sex="MALE">
             <persName>Ford</persName>
           </person>
-          <person xml:id="Robin_Wiv">
+          <person xml:id="Robin_Wiv" sex="MALE">
             <persName>Robin</persName>
           </person>
-          <person xml:id="Robert_Wiv">
+          <person xml:id="Robert_Wiv" sex="MALE">
             <persName>Robert</persName>
           </person>
-          <person xml:id="John_Wiv">
+          <person xml:id="John_Wiv" sex="MALE">
             <persName>John</persName>
           </person>
-          <person xml:id="WilliamPage_Wiv">
+          <person xml:id="WilliamPage_Wiv" sex="MALE">
             <persName>William</persName>
           </person>
-          <person xml:id="BOYS_Wiv">
-            <persName>Windsor Children, disguised as fairies</persName>
-          </person>
+          <personGrp xml:id="BOYS_Wiv" sex="UNKNOWN">
+            <name>Windsor Children, disguised as fairies</name>
+          </personGrp>
         </listPerson>
       </particDesc>
     </profileDesc>

--- a/tei/the-taming-of-the-shrew.xml
+++ b/tei/the-taming-of-the-shrew.xml
@@ -88,118 +88,118 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Sly_Shr">
+          <person xml:id="Sly_Shr" sex="MALE">
             <persName>Christopher Sly</persName>
           </person>
-          <person xml:id="Hostess_Shr">
-            <persName>characters in the Induction</persName>
-          </person>
-          <person xml:id="Lord_Shr">
-            <persName>characters in the Induction</persName>
-          </person>
-          <person xml:id="HUNTSMEN.0.1_Shr">
-            <persName>characters in the Induction</persName>
-          </person>
-          <person xml:id="HUNTSMEN.0.2_Shr">
-            <persName>characters in the Induction</persName>
-          </person>
-          <person xml:id="HUNTSMEN.0.3_Shr">
-            <persName>characters in the Induction</persName>
-          </person>
-          <person xml:id="SERVANTS.LORD.0.1_Shr">
-            <persName>characters in the Induction</persName>
-          </person>
-          <person xml:id="PLAYERS_Shr">
-            <persName>characters in the Induction</persName>
-          </person>
-          <person xml:id="PLAYERS.0.1_Shr">
-            <persName>characters in the Induction</persName>
-          </person>
-          <person xml:id="PLAYERS.0.2_Shr">
-            <persName>characters in the Induction</persName>
-          </person>
-          <person xml:id="SERVANTS.LORD.0.2_Shr">
-            <persName>characters in the Induction</persName>
-          </person>
-          <person xml:id="SERVANTS.LORD.0.3_Shr">
-            <persName>characters in the Induction</persName>
-          </person>
-          <person xml:id="SERVANTS.LORD_Shr">
-            <persName>characters in the Induction</persName>
-          </person>
-          <person xml:id="Page_Shr">
-            <persName>characters in the Induction</persName>
-          </person>
-          <person xml:id="Messenger_Shr">
-            <persName>characters in the Induction</persName>
-          </person>
-          <person xml:id="Lucentio_Shr">
+          <personGrp xml:id="Hostess_Shr" sex="UNKNOWN">
+            <name>characters in the Induction</name>
+          </personGrp>
+          <personGrp xml:id="Lord_Shr" sex="UNKNOWN">
+            <name>characters in the Induction</name>
+          </personGrp>
+          <personGrp xml:id="HUNTSMEN.0.1_Shr" sex="UNKNOWN">
+            <name>characters in the Induction</name>
+          </personGrp>
+          <personGrp xml:id="HUNTSMEN.0.2_Shr" sex="UNKNOWN">
+            <name>characters in the Induction</name>
+          </personGrp>
+          <personGrp xml:id="HUNTSMEN.0.3_Shr" sex="UNKNOWN">
+            <name>characters in the Induction</name>
+          </personGrp>
+          <personGrp xml:id="SERVANTS.LORD.0.1_Shr" sex="UNKNOWN">
+            <name>characters in the Induction</name>
+          </personGrp>
+          <personGrp xml:id="PLAYERS_Shr" sex="UNKNOWN">
+            <name>characters in the Induction</name>
+          </personGrp>
+          <personGrp xml:id="PLAYERS.0.1_Shr" sex="UNKNOWN">
+            <name>characters in the Induction</name>
+          </personGrp>
+          <personGrp xml:id="PLAYERS.0.2_Shr" sex="UNKNOWN">
+            <name>characters in the Induction</name>
+          </personGrp>
+          <personGrp xml:id="SERVANTS.LORD.0.2_Shr" sex="UNKNOWN">
+            <name>characters in the Induction</name>
+          </personGrp>
+          <personGrp xml:id="SERVANTS.LORD.0.3_Shr" sex="UNKNOWN">
+            <name>characters in the Induction</name>
+          </personGrp>
+          <personGrp xml:id="SERVANTS.LORD_Shr" sex="UNKNOWN">
+            <name>characters in the Induction</name>
+          </personGrp>
+          <personGrp xml:id="Page_Shr" sex="UNKNOWN">
+            <name>characters in the Induction</name>
+          </personGrp>
+          <personGrp xml:id="Messenger_Shr" sex="UNKNOWN">
+            <name>characters in the Induction</name>
+          </personGrp>
+          <person xml:id="Lucentio_Shr" sex="MALE">
             <persName>Lucentio</persName>
           </person>
-          <person xml:id="Tranio_Shr">
+          <person xml:id="Tranio_Shr" sex="MALE">
             <persName>Tranio</persName>
           </person>
-          <person xml:id="Baptista_Shr">
+          <person xml:id="Baptista_Shr" sex="MALE">
             <persName>Baptista Minola</persName>
           </person>
-          <person xml:id="Gremio_Shr">
+          <person xml:id="Gremio_Shr" sex="MALE">
             <persName>Gremio</persName>
           </person>
-          <person xml:id="Katherine_Shr">
+          <person xml:id="Katherine_Shr" sex="FEMALE">
             <persName>Katherine</persName>
           </person>
-          <person xml:id="Hortensio_Shr">
+          <person xml:id="Hortensio_Shr" sex="MALE">
             <persName>Hortensio</persName>
           </person>
-          <person xml:id="Bianca_Shr">
+          <person xml:id="Bianca_Shr" sex="FEMALE">
             <persName>Bianca</persName>
           </person>
-          <person xml:id="Biondello_Shr">
+          <person xml:id="Biondello_Shr" sex="MALE">
             <persName>Biondello</persName>
           </person>
-          <person xml:id="Petruchio_Shr">
+          <person xml:id="Petruchio_Shr" sex="MALE">
             <persName>Petruchio</persName>
           </person>
-          <person xml:id="Grumio_Shr">
+          <person xml:id="Grumio_Shr" sex="MALE">
             <persName>Grumio</persName>
           </person>
-          <person xml:id="SERVANTS.BAPTISTA.1_Shr">
+          <person xml:id="SERVANTS.BAPTISTA.1_Shr" sex="UNKNOWN">
             <persName>SERVANTS.BAPTISTA.1_Shr</persName>
           </person>
-          <person xml:id="Curtis_Shr">
+          <person xml:id="Curtis_Shr" sex="MALE">
             <persName>Curtis</persName>
           </person>
-          <person xml:id="SERVANTS.PETRUCHIO.Nathaniel_Shr">
+          <person xml:id="SERVANTS.PETRUCHIO.Nathaniel_Shr" sex="MALE">
             <persName>Nathaniel</persName>
           </person>
-          <person xml:id="SERVANTS.PETRUCHIO.Phillip_Shr">
+          <person xml:id="SERVANTS.PETRUCHIO.Phillip_Shr" sex="MALE">
             <persName>Phillip</persName>
           </person>
-          <person xml:id="SERVANTS.PETRUCHIO.Joseph_Shr">
+          <person xml:id="SERVANTS.PETRUCHIO.Joseph_Shr" sex="MALE">
             <persName>Joseph</persName>
           </person>
-          <person xml:id="SERVANTS.PETRUCHIO.Nicholas_Shr">
+          <person xml:id="SERVANTS.PETRUCHIO.Nicholas_Shr" sex="MALE">
             <persName>Nicholas</persName>
           </person>
-          <person xml:id="SERVANTS.PETRUCHIO.Peter_Shr">
+          <person xml:id="SERVANTS.PETRUCHIO.Peter_Shr" sex="MALE">
             <persName>Peter</persName>
           </person>
-          <person xml:id="SERVANTS.PETRUCHIO.0.4_Shr">
+          <person xml:id="SERVANTS.PETRUCHIO.0.4_Shr" sex="UNKNOWN">
             <persName>SERVANTS.PETRUCHIO.0.4_Shr</persName>
           </person>
-          <person xml:id="Merchant_Shr">
+          <person xml:id="Merchant_Shr" sex="MALE">
             <persName>Merchant_Shr</persName>
           </person>
-          <person xml:id="Haberdasher_Shr">
+          <person xml:id="Haberdasher_Shr" sex="MALE">
             <persName>Haberdasher_Shr</persName>
           </person>
-          <person xml:id="Tailor_Shr">
+          <person xml:id="Tailor_Shr" sex="MALE">
             <persName>Tailor_Shr</persName>
           </person>
-          <person xml:id="Vincentio_Shr">
+          <person xml:id="Vincentio_Shr" sex="MALE">
             <persName>Vincentio</persName>
           </person>
-          <person xml:id="Widow_Shr">
+          <person xml:id="Widow_Shr" sex="FEMALE">
             <persName>Widow_Shr</persName>
           </person>
         </listPerson>

--- a/tei/the-taming-of-the-shrew.xml
+++ b/tei/the-taming-of-the-shrew.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,125 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Sly_Shr"><persName>Christopher Sly</persName></person><person xml:id="Hostess_Shr"><persName>characters in the Induction</persName></person><person xml:id="Lord_Shr"><persName>characters in the Induction</persName></person><person xml:id="HUNTSMEN.0.1_Shr"><persName>characters in the Induction</persName></person><person xml:id="HUNTSMEN.0.2_Shr"><persName>characters in the Induction</persName></person><person xml:id="HUNTSMEN.0.3_Shr"><persName>characters in the Induction</persName></person><person xml:id="SERVANTS.LORD.0.1_Shr"><persName>characters in the Induction</persName></person><person xml:id="PLAYERS_Shr"><persName>characters in the Induction</persName></person><person xml:id="PLAYERS.0.1_Shr"><persName>characters in the Induction</persName></person><person xml:id="PLAYERS.0.2_Shr"><persName>characters in the Induction</persName></person><person xml:id="SERVANTS.LORD.0.2_Shr"><persName>characters in the Induction</persName></person><person xml:id="SERVANTS.LORD.0.3_Shr"><persName>characters in the Induction</persName></person><person xml:id="SERVANTS.LORD_Shr"><persName>characters in the Induction</persName></person><person xml:id="Page_Shr"><persName>characters in the Induction</persName></person><person xml:id="Messenger_Shr"><persName>characters in the Induction</persName></person><person xml:id="Lucentio_Shr"><persName>Lucentio</persName></person><person xml:id="Tranio_Shr"><persName>Tranio</persName></person><person xml:id="Baptista_Shr"><persName>Baptista Minola</persName></person><person xml:id="Gremio_Shr"><persName>Gremio</persName></person><person xml:id="Katherine_Shr"><persName>Katherine</persName></person><person xml:id="Hortensio_Shr"><persName>Hortensio</persName></person><person xml:id="Bianca_Shr"><persName>Bianca</persName></person><person xml:id="Biondello_Shr"><persName>Biondello</persName></person><person xml:id="Petruchio_Shr"><persName>Petruchio</persName></person><person xml:id="Grumio_Shr"><persName>Grumio</persName></person><person xml:id="SERVANTS.BAPTISTA.1_Shr"><persName>SERVANTS.BAPTISTA.1_Shr</persName></person><person xml:id="Curtis_Shr"><persName>Curtis</persName></person><person xml:id="SERVANTS.PETRUCHIO.Nathaniel_Shr"><persName>Nathaniel</persName></person><person xml:id="SERVANTS.PETRUCHIO.Phillip_Shr"><persName>Phillip</persName></person><person xml:id="SERVANTS.PETRUCHIO.Joseph_Shr"><persName>Joseph</persName></person><person xml:id="SERVANTS.PETRUCHIO.Nicholas_Shr"><persName>Nicholas</persName></person><person xml:id="SERVANTS.PETRUCHIO.Peter_Shr"><persName>Peter</persName></person><person xml:id="SERVANTS.PETRUCHIO.0.4_Shr"><persName>SERVANTS.PETRUCHIO.0.4_Shr</persName></person><person xml:id="Merchant_Shr"><persName>Merchant_Shr</persName></person><person xml:id="Haberdasher_Shr"><persName>Haberdasher_Shr</persName></person><person xml:id="Tailor_Shr"><persName>Tailor_Shr</persName></person><person xml:id="Vincentio_Shr"><persName>Vincentio</persName></person><person xml:id="Widow_Shr"><persName>Widow_Shr</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Sly_Shr">
+            <persName>Christopher Sly</persName>
+          </person>
+          <person xml:id="Hostess_Shr">
+            <persName>characters in the Induction</persName>
+          </person>
+          <person xml:id="Lord_Shr">
+            <persName>characters in the Induction</persName>
+          </person>
+          <person xml:id="HUNTSMEN.0.1_Shr">
+            <persName>characters in the Induction</persName>
+          </person>
+          <person xml:id="HUNTSMEN.0.2_Shr">
+            <persName>characters in the Induction</persName>
+          </person>
+          <person xml:id="HUNTSMEN.0.3_Shr">
+            <persName>characters in the Induction</persName>
+          </person>
+          <person xml:id="SERVANTS.LORD.0.1_Shr">
+            <persName>characters in the Induction</persName>
+          </person>
+          <person xml:id="PLAYERS_Shr">
+            <persName>characters in the Induction</persName>
+          </person>
+          <person xml:id="PLAYERS.0.1_Shr">
+            <persName>characters in the Induction</persName>
+          </person>
+          <person xml:id="PLAYERS.0.2_Shr">
+            <persName>characters in the Induction</persName>
+          </person>
+          <person xml:id="SERVANTS.LORD.0.2_Shr">
+            <persName>characters in the Induction</persName>
+          </person>
+          <person xml:id="SERVANTS.LORD.0.3_Shr">
+            <persName>characters in the Induction</persName>
+          </person>
+          <person xml:id="SERVANTS.LORD_Shr">
+            <persName>characters in the Induction</persName>
+          </person>
+          <person xml:id="Page_Shr">
+            <persName>characters in the Induction</persName>
+          </person>
+          <person xml:id="Messenger_Shr">
+            <persName>characters in the Induction</persName>
+          </person>
+          <person xml:id="Lucentio_Shr">
+            <persName>Lucentio</persName>
+          </person>
+          <person xml:id="Tranio_Shr">
+            <persName>Tranio</persName>
+          </person>
+          <person xml:id="Baptista_Shr">
+            <persName>Baptista Minola</persName>
+          </person>
+          <person xml:id="Gremio_Shr">
+            <persName>Gremio</persName>
+          </person>
+          <person xml:id="Katherine_Shr">
+            <persName>Katherine</persName>
+          </person>
+          <person xml:id="Hortensio_Shr">
+            <persName>Hortensio</persName>
+          </person>
+          <person xml:id="Bianca_Shr">
+            <persName>Bianca</persName>
+          </person>
+          <person xml:id="Biondello_Shr">
+            <persName>Biondello</persName>
+          </person>
+          <person xml:id="Petruchio_Shr">
+            <persName>Petruchio</persName>
+          </person>
+          <person xml:id="Grumio_Shr">
+            <persName>Grumio</persName>
+          </person>
+          <person xml:id="SERVANTS.BAPTISTA.1_Shr">
+            <persName>SERVANTS.BAPTISTA.1_Shr</persName>
+          </person>
+          <person xml:id="Curtis_Shr">
+            <persName>Curtis</persName>
+          </person>
+          <person xml:id="SERVANTS.PETRUCHIO.Nathaniel_Shr">
+            <persName>Nathaniel</persName>
+          </person>
+          <person xml:id="SERVANTS.PETRUCHIO.Phillip_Shr">
+            <persName>Phillip</persName>
+          </person>
+          <person xml:id="SERVANTS.PETRUCHIO.Joseph_Shr">
+            <persName>Joseph</persName>
+          </person>
+          <person xml:id="SERVANTS.PETRUCHIO.Nicholas_Shr">
+            <persName>Nicholas</persName>
+          </person>
+          <person xml:id="SERVANTS.PETRUCHIO.Peter_Shr">
+            <persName>Peter</persName>
+          </person>
+          <person xml:id="SERVANTS.PETRUCHIO.0.4_Shr">
+            <persName>SERVANTS.PETRUCHIO.0.4_Shr</persName>
+          </person>
+          <person xml:id="Merchant_Shr">
+            <persName>Merchant_Shr</persName>
+          </person>
+          <person xml:id="Haberdasher_Shr">
+            <persName>Haberdasher_Shr</persName>
+          </person>
+          <person xml:id="Tailor_Shr">
+            <persName>Tailor_Shr</persName>
+          </person>
+          <person xml:id="Vincentio_Shr">
+            <persName>Vincentio</persName>
+          </person>
+          <person xml:id="Widow_Shr">
+            <persName>Widow_Shr</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/the-tempest.xml
+++ b/tei/the-tempest.xml
@@ -88,61 +88,61 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Shipmaster_Tmp">
+          <person xml:id="Shipmaster_Tmp" sex="MALE">
             <persName>Shipmaster</persName>
           </person>
-          <person xml:id="Boatswain_Tmp">
+          <person xml:id="Boatswain_Tmp" sex="MALE">
             <persName>Boatswain</persName>
           </person>
-          <person xml:id="Alonso_Tmp">
+          <person xml:id="Alonso_Tmp" sex="MALE">
             <persName>Alonso</persName>
           </person>
-          <person xml:id="Antonio_Tmp">
+          <person xml:id="Antonio_Tmp" sex="MALE">
             <persName>Antonio</persName>
           </person>
-          <person xml:id="Gonzalo_Tmp">
+          <person xml:id="Gonzalo_Tmp" sex="MALE">
             <persName>Gonzalo</persName>
           </person>
-          <person xml:id="Sebastian_Tmp">
+          <person xml:id="Sebastian_Tmp" sex="MALE">
             <persName>Sebastian</persName>
           </person>
-          <person xml:id="SAILORS_Tmp">
-            <persName>Mariners</persName>
-          </person>
-          <person xml:id="Miranda_Tmp">
+          <personGrp xml:id="SAILORS_Tmp" sex="UNKNOWN">
+            <name>Mariners</name>
+          </personGrp>
+          <person xml:id="Miranda_Tmp" sex="FEMALE">
             <persName>Miranda</persName>
           </person>
-          <person xml:id="Prospero_Tmp">
+          <person xml:id="Prospero_Tmp" sex="MALE">
             <persName>Prospero</persName>
           </person>
-          <person xml:id="Ariel_Tmp">
+          <person xml:id="Ariel_Tmp" sex="UNKNOWN">
             <persName>Ariel</persName>
           </person>
-          <person xml:id="Caliban_Tmp">
+          <person xml:id="Caliban_Tmp" sex="MALE">
             <persName>Caliban</persName>
           </person>
-          <person xml:id="Ferdinand_Tmp">
+          <person xml:id="Ferdinand_Tmp" sex="MALE">
             <persName>Ferdinand</persName>
           </person>
-          <person xml:id="Adrian_Tmp">
+          <person xml:id="Adrian_Tmp" sex="MALE">
             <persName>Adrian</persName>
           </person>
-          <person xml:id="Francisco_Tmp">
+          <person xml:id="Francisco_Tmp" sex="MALE">
             <persName>Francisco</persName>
           </person>
-          <person xml:id="Trinculo_Tmp">
+          <person xml:id="Trinculo_Tmp" sex="MALE">
             <persName>Trinculo</persName>
           </person>
-          <person xml:id="Stephano_Tmp">
+          <person xml:id="Stephano_Tmp" sex="MALE">
             <persName>Stephano</persName>
           </person>
-          <person xml:id="SPIRITS.Iris_Tmp">
+          <person xml:id="SPIRITS.Iris_Tmp" sex="FEMALE">
             <persName>SPIRITS.Iris_Tmp</persName>
           </person>
-          <person xml:id="SPIRITS.Ceres_Tmp">
+          <person xml:id="SPIRITS.Ceres_Tmp" sex="FEMALE">
             <persName>SPIRITS.Ceres_Tmp</persName>
           </person>
-          <person xml:id="SPIRITS.Juno_Tmp">
+          <person xml:id="SPIRITS.Juno_Tmp" sex="FEMALE">
             <persName>SPIRITS.Juno_Tmp</persName>
           </person>
         </listPerson>

--- a/tei/the-tempest.xml
+++ b/tei/the-tempest.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,68 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Shipmaster_Tmp"><persName>Shipmaster</persName></person><person xml:id="Boatswain_Tmp"><persName>Boatswain</persName></person><person xml:id="Alonso_Tmp"><persName>Alonso</persName></person><person xml:id="Antonio_Tmp"><persName>Antonio</persName></person><person xml:id="Gonzalo_Tmp"><persName>Gonzalo</persName></person><person xml:id="Sebastian_Tmp"><persName>Sebastian</persName></person><person xml:id="SAILORS_Tmp"><persName>Mariners</persName></person><person xml:id="Miranda_Tmp"><persName>Miranda</persName></person><person xml:id="Prospero_Tmp"><persName>Prospero</persName></person><person xml:id="Ariel_Tmp"><persName>Ariel</persName></person><person xml:id="Caliban_Tmp"><persName>Caliban</persName></person><person xml:id="Ferdinand_Tmp"><persName>Ferdinand</persName></person><person xml:id="Adrian_Tmp"><persName>Adrian</persName></person><person xml:id="Francisco_Tmp"><persName>Francisco</persName></person><person xml:id="Trinculo_Tmp"><persName>Trinculo</persName></person><person xml:id="Stephano_Tmp"><persName>Stephano</persName></person><person xml:id="SPIRITS.Iris_Tmp"><persName>SPIRITS.Iris_Tmp</persName></person><person xml:id="SPIRITS.Ceres_Tmp"><persName>SPIRITS.Ceres_Tmp</persName></person><person xml:id="SPIRITS.Juno_Tmp"><persName>SPIRITS.Juno_Tmp</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Shipmaster_Tmp">
+            <persName>Shipmaster</persName>
+          </person>
+          <person xml:id="Boatswain_Tmp">
+            <persName>Boatswain</persName>
+          </person>
+          <person xml:id="Alonso_Tmp">
+            <persName>Alonso</persName>
+          </person>
+          <person xml:id="Antonio_Tmp">
+            <persName>Antonio</persName>
+          </person>
+          <person xml:id="Gonzalo_Tmp">
+            <persName>Gonzalo</persName>
+          </person>
+          <person xml:id="Sebastian_Tmp">
+            <persName>Sebastian</persName>
+          </person>
+          <person xml:id="SAILORS_Tmp">
+            <persName>Mariners</persName>
+          </person>
+          <person xml:id="Miranda_Tmp">
+            <persName>Miranda</persName>
+          </person>
+          <person xml:id="Prospero_Tmp">
+            <persName>Prospero</persName>
+          </person>
+          <person xml:id="Ariel_Tmp">
+            <persName>Ariel</persName>
+          </person>
+          <person xml:id="Caliban_Tmp">
+            <persName>Caliban</persName>
+          </person>
+          <person xml:id="Ferdinand_Tmp">
+            <persName>Ferdinand</persName>
+          </person>
+          <person xml:id="Adrian_Tmp">
+            <persName>Adrian</persName>
+          </person>
+          <person xml:id="Francisco_Tmp">
+            <persName>Francisco</persName>
+          </person>
+          <person xml:id="Trinculo_Tmp">
+            <persName>Trinculo</persName>
+          </person>
+          <person xml:id="Stephano_Tmp">
+            <persName>Stephano</persName>
+          </person>
+          <person xml:id="SPIRITS.Iris_Tmp">
+            <persName>SPIRITS.Iris_Tmp</persName>
+          </person>
+          <person xml:id="SPIRITS.Ceres_Tmp">
+            <persName>SPIRITS.Ceres_Tmp</persName>
+          </person>
+          <person xml:id="SPIRITS.Juno_Tmp">
+            <persName>SPIRITS.Juno_Tmp</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/the-winter-s-tale.xml
+++ b/tei/the-winter-s-tale.xml
@@ -88,109 +88,109 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Archidamus_WT">
+          <person xml:id="Archidamus_WT" sex="MALE">
             <persName>Archidamus</persName>
           </person>
-          <person xml:id="Camillo_WT">
+          <person xml:id="Camillo_WT" sex="MALE">
             <persName>Camillo</persName>
           </person>
-          <person xml:id="Polixenes_WT">
+          <person xml:id="Polixenes_WT" sex="MALE">
             <persName>Polixenes</persName>
           </person>
-          <person xml:id="Leontes_WT">
+          <person xml:id="Leontes_WT" sex="MALE">
             <persName>Leontes</persName>
           </person>
-          <person xml:id="Hermione_WT">
+          <person xml:id="Hermione_WT" sex="FEMALE">
             <persName>Hermione</persName>
           </person>
-          <person xml:id="Mamillius_WT">
+          <person xml:id="Mamillius_WT" sex="MALE">
             <persName>Mamillius</persName>
           </person>
-          <person xml:id="LADIES.0.1_WT">
-            <persName>LADIES.0.1_WT</persName>
-          </person>
-          <person xml:id="LADIES.0.2_WT">
-            <persName>LADIES.0.2_WT</persName>
-          </person>
-          <person xml:id="ATTENDANTS.0.1_WT">
-            <persName>ATTENDANTS.0.1_WT</persName>
-          </person>
-          <person xml:id="Antigonus_WT">
+          <personGrp xml:id="LADIES.0.1_WT" sex="UNKNOWN">
+            <name>LADIES.0.1_WT</name>
+          </personGrp>
+          <personGrp xml:id="LADIES.0.2_WT" sex="UNKNOWN">
+            <name>LADIES.0.2_WT</name>
+          </personGrp>
+          <personGrp xml:id="ATTENDANTS.0.1_WT" sex="UNKNOWN">
+            <name>ATTENDANTS.0.1_WT</name>
+          </personGrp>
+          <person xml:id="Antigonus_WT" sex="MALE">
             <persName>Antigonus</persName>
           </person>
-          <person xml:id="Paulina_WT">
+          <person xml:id="Paulina_WT" sex="FEMALE">
             <persName>Paulina</persName>
           </person>
-          <person xml:id="Jailer_WT">
+          <person xml:id="Jailer_WT" sex="MALE">
             <persName>Jailer</persName>
           </person>
-          <person xml:id="LADIES.Emilia_WT">
+          <person xml:id="LADIES.Emilia_WT" sex="FEMALE">
             <persName>Emilia</persName>
           </person>
-          <person xml:id="SERVANTS.X.1_WT">
-            <persName>Indeterminate member of the SERVANTS group</persName>
-          </person>
-          <person xml:id="SERVANTS.0_WT">
-            <persName>Indistinct members of the SERVANTS group</persName>
-          </person>
-          <person xml:id="ATTENDANTS_WT">
+          <personGrp xml:id="SERVANTS.X.1_WT" sex="UNKNOWN">
+            <name>Indeterminate member of the SERVANTS group</name>
+          </personGrp>
+          <personGrp xml:id="SERVANTS.0_WT" sex="UNKNOWN">
+            <name>Indistinct members of the SERVANTS group</name>
+          </personGrp>
+          <person xml:id="ATTENDANTS_WT" sex="MALE">
             <persName>ATTENDANTS_WT</persName>
           </person>
-          <person xml:id="SERVANTS.X.2_WT">
-            <persName>Indeterminate member of the SERVANTS group</persName>
-          </person>
-          <person xml:id="Cleomenes_WT">
+          <personGrp xml:id="SERVANTS.X.2_WT" sex="UNKNOWN">
+            <name>Indeterminate member of the SERVANTS group</name>
+          </personGrp>
+          <person xml:id="Cleomenes_WT" sex="MALE">
             <persName>Cleomenes</persName>
           </person>
-          <person xml:id="Dion_WT">
+          <person xml:id="Dion_WT" sex="MALE">
             <persName>Dion</persName>
           </person>
-          <person xml:id="OFFICERS.0.1_WT">
+          <person sex="" xml:id="OFFICERS.0.1_WT">
             <persName>Officer</persName>
           </person>
-          <person xml:id="Sailor_WT">
+          <person sex="" xml:id="Sailor_WT">
             <persName>Mariner</persName>
           </person>
-          <person xml:id="Shepherd_WT">
+          <person xml:id="Shepherd_WT" sex="MALE">
             <persName>Shepherd</persName>
           </person>
-          <person xml:id="ShepherdsSon_WT">
+          <person xml:id="ShepherdsSon_WT" sex="MALE">
             <persName>Shepherd’s Son</persName>
           </person>
-          <person xml:id="Chorus_WT">
+          <person xml:id="Chorus_WT" sex="UNKNOWN">
             <persName>Time</persName>
           </person>
-          <person xml:id="Autolycus_WT">
+          <person xml:id="Autolycus_WT" sex="MALE">
             <persName>Autolycus</persName>
           </person>
-          <person xml:id="Florizell_WT">
+          <person xml:id="Florizell_WT" sex="MALE">
             <persName>Florizell</persName>
           </person>
-          <person xml:id="Perdita_WT">
+          <person xml:id="Perdita_WT" sex="FEMALE">
             <persName>Perdita</persName>
           </person>
-          <person xml:id="Dorcas_WT">
+          <person xml:id="Dorcas_WT" sex="FEMALE">
             <persName>Dorcas</persName>
           </person>
-          <person xml:id="Mopsa_WT">
+          <person xml:id="Mopsa_WT" sex="FEMALE">
             <persName>Mopsa</persName>
           </person>
-          <person xml:id="SERVANTS.SHEPHERD.1_WT">
+          <person xml:id="SERVANTS.SHEPHERD.1_WT" sex="MALE">
             <persName>Servant</persName>
           </person>
-          <person xml:id="SERVANTS.X.3_WT">
-            <persName>Indeterminate member of the SERVANTS group</persName>
-          </person>
-          <person xml:id="ATTENDANTS.X_WT">
+          <personGrp xml:id="SERVANTS.X.3_WT" sex="UNKNOWN">
+            <name>Indeterminate member of the SERVANTS group</name>
+          </personGrp>
+          <person xml:id="ATTENDANTS.X_WT" sex="MALE">
             <persName>ATTENDANTS.X_WT</persName>
           </person>
-          <person xml:id="ATTENDANTS.1_WT">
+          <person xml:id="ATTENDANTS.1_WT" sex="MALE">
             <persName>ATTENDANTS.1_WT</persName>
           </person>
-          <person xml:id="ATTENDANTS.2_WT">
+          <person xml:id="ATTENDANTS.2_WT" sex="MALE">
             <persName>ATTENDANTS.2_WT</persName>
           </person>
-          <person xml:id="ATTENDANTS.3_WT">
+          <person xml:id="ATTENDANTS.3_WT" sex="MALE">
             <persName>ATTENDANTS.3_WT</persName>
           </person>
         </listPerson>

--- a/tei/the-winter-s-tale.xml
+++ b/tei/the-winter-s-tale.xml
@@ -145,10 +145,10 @@
           <person xml:id="Dion_WT" sex="MALE">
             <persName>Dion</persName>
           </person>
-          <person sex="" xml:id="OFFICERS.0.1_WT">
+          <person xml:id="OFFICERS.0.1_WT">
             <persName>Officer</persName>
           </person>
-          <person sex="" xml:id="Sailor_WT">
+          <person xml:id="Sailor_WT">
             <persName>Mariner</persName>
           </person>
           <person xml:id="Shepherd_WT" sex="MALE">

--- a/tei/the-winter-s-tale.xml
+++ b/tei/the-winter-s-tale.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,116 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Archidamus_WT"><persName>Archidamus</persName></person><person xml:id="Camillo_WT"><persName>Camillo</persName></person><person xml:id="Polixenes_WT"><persName>Polixenes</persName></person><person xml:id="Leontes_WT"><persName>Leontes</persName></person><person xml:id="Hermione_WT"><persName>Hermione</persName></person><person xml:id="Mamillius_WT"><persName>Mamillius</persName></person><person xml:id="LADIES.0.1_WT"><persName>LADIES.0.1_WT</persName></person><person xml:id="LADIES.0.2_WT"><persName>LADIES.0.2_WT</persName></person><person xml:id="ATTENDANTS.0.1_WT"><persName>ATTENDANTS.0.1_WT</persName></person><person xml:id="Antigonus_WT"><persName>Antigonus</persName></person><person xml:id="Paulina_WT"><persName>Paulina</persName></person><person xml:id="Jailer_WT"><persName>Jailer</persName></person><person xml:id="LADIES.Emilia_WT"><persName>Emilia</persName></person><person xml:id="SERVANTS.X.1_WT"><persName>Indeterminate member of the SERVANTS group</persName></person><person xml:id="SERVANTS.0_WT"><persName>Indistinct members of the SERVANTS group</persName></person><person xml:id="ATTENDANTS_WT"><persName>ATTENDANTS_WT</persName></person><person xml:id="SERVANTS.X.2_WT"><persName>Indeterminate member of the SERVANTS group</persName></person><person xml:id="Cleomenes_WT"><persName>Cleomenes</persName></person><person xml:id="Dion_WT"><persName>Dion</persName></person><person xml:id="OFFICERS.0.1_WT"><persName>Officer</persName></person><person xml:id="Sailor_WT"><persName>Mariner</persName></person><person xml:id="Shepherd_WT"><persName>Shepherd</persName></person><person xml:id="ShepherdsSon_WT"><persName>Shepherd’s Son</persName></person><person xml:id="Chorus_WT"><persName>Time</persName></person><person xml:id="Autolycus_WT"><persName>Autolycus</persName></person><person xml:id="Florizell_WT"><persName>Florizell</persName></person><person xml:id="Perdita_WT"><persName>Perdita</persName></person><person xml:id="Dorcas_WT"><persName>Dorcas</persName></person><person xml:id="Mopsa_WT"><persName>Mopsa</persName></person><person xml:id="SERVANTS.SHEPHERD.1_WT"><persName>Servant</persName></person><person xml:id="SERVANTS.X.3_WT"><persName>Indeterminate member of the SERVANTS group</persName></person><person xml:id="ATTENDANTS.X_WT"><persName>ATTENDANTS.X_WT</persName></person><person xml:id="ATTENDANTS.1_WT"><persName>ATTENDANTS.1_WT</persName></person><person xml:id="ATTENDANTS.2_WT"><persName>ATTENDANTS.2_WT</persName></person><person xml:id="ATTENDANTS.3_WT"><persName>ATTENDANTS.3_WT</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Archidamus_WT">
+            <persName>Archidamus</persName>
+          </person>
+          <person xml:id="Camillo_WT">
+            <persName>Camillo</persName>
+          </person>
+          <person xml:id="Polixenes_WT">
+            <persName>Polixenes</persName>
+          </person>
+          <person xml:id="Leontes_WT">
+            <persName>Leontes</persName>
+          </person>
+          <person xml:id="Hermione_WT">
+            <persName>Hermione</persName>
+          </person>
+          <person xml:id="Mamillius_WT">
+            <persName>Mamillius</persName>
+          </person>
+          <person xml:id="LADIES.0.1_WT">
+            <persName>LADIES.0.1_WT</persName>
+          </person>
+          <person xml:id="LADIES.0.2_WT">
+            <persName>LADIES.0.2_WT</persName>
+          </person>
+          <person xml:id="ATTENDANTS.0.1_WT">
+            <persName>ATTENDANTS.0.1_WT</persName>
+          </person>
+          <person xml:id="Antigonus_WT">
+            <persName>Antigonus</persName>
+          </person>
+          <person xml:id="Paulina_WT">
+            <persName>Paulina</persName>
+          </person>
+          <person xml:id="Jailer_WT">
+            <persName>Jailer</persName>
+          </person>
+          <person xml:id="LADIES.Emilia_WT">
+            <persName>Emilia</persName>
+          </person>
+          <person xml:id="SERVANTS.X.1_WT">
+            <persName>Indeterminate member of the SERVANTS group</persName>
+          </person>
+          <person xml:id="SERVANTS.0_WT">
+            <persName>Indistinct members of the SERVANTS group</persName>
+          </person>
+          <person xml:id="ATTENDANTS_WT">
+            <persName>ATTENDANTS_WT</persName>
+          </person>
+          <person xml:id="SERVANTS.X.2_WT">
+            <persName>Indeterminate member of the SERVANTS group</persName>
+          </person>
+          <person xml:id="Cleomenes_WT">
+            <persName>Cleomenes</persName>
+          </person>
+          <person xml:id="Dion_WT">
+            <persName>Dion</persName>
+          </person>
+          <person xml:id="OFFICERS.0.1_WT">
+            <persName>Officer</persName>
+          </person>
+          <person xml:id="Sailor_WT">
+            <persName>Mariner</persName>
+          </person>
+          <person xml:id="Shepherd_WT">
+            <persName>Shepherd</persName>
+          </person>
+          <person xml:id="ShepherdsSon_WT">
+            <persName>Shepherd’s Son</persName>
+          </person>
+          <person xml:id="Chorus_WT">
+            <persName>Time</persName>
+          </person>
+          <person xml:id="Autolycus_WT">
+            <persName>Autolycus</persName>
+          </person>
+          <person xml:id="Florizell_WT">
+            <persName>Florizell</persName>
+          </person>
+          <person xml:id="Perdita_WT">
+            <persName>Perdita</persName>
+          </person>
+          <person xml:id="Dorcas_WT">
+            <persName>Dorcas</persName>
+          </person>
+          <person xml:id="Mopsa_WT">
+            <persName>Mopsa</persName>
+          </person>
+          <person xml:id="SERVANTS.SHEPHERD.1_WT">
+            <persName>Servant</persName>
+          </person>
+          <person xml:id="SERVANTS.X.3_WT">
+            <persName>Indeterminate member of the SERVANTS group</persName>
+          </person>
+          <person xml:id="ATTENDANTS.X_WT">
+            <persName>ATTENDANTS.X_WT</persName>
+          </person>
+          <person xml:id="ATTENDANTS.1_WT">
+            <persName>ATTENDANTS.1_WT</persName>
+          </person>
+          <person xml:id="ATTENDANTS.2_WT">
+            <persName>ATTENDANTS.2_WT</persName>
+          </person>
+          <person xml:id="ATTENDANTS.3_WT">
+            <persName>ATTENDANTS.3_WT</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/timon-of-athens.xml
+++ b/tei/timon-of-athens.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,216 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Poet_Tim"><persName>Poet</persName></person><person xml:id="Painter_Tim"><persName>Painter</persName></person><person xml:id="Merchant_Tim"><persName>Merchant</persName></person><person xml:id="Jeweler_Tim"><persName>Jeweler</persName></person><person xml:id="Timon_Tim"><persName>Timon</persName></person><person xml:id="MESSENGERS.X.1_Tim"><persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName></person><person xml:id="OldMan_Tim"><persName>Old Athenian</persName></person><person xml:id="SERVANTS.TIMON.Lucilius_Tim"><persName>Lucilius</persName></person><person xml:id="Apemantus_Tim"><persName>Apemantus</persName></person><person xml:id="MESSENGERS.X.2_Tim"><persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName></person><person xml:id="Alcibiades_Tim"><persName>Alcibiades</persName></person><person xml:id="LORDS.0.1_Tim"><persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName></person><person xml:id="LORDS.0.2_Tim"><persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName></person><person xml:id="FRIENDS.Ventidius_Tim"><persName>Ventidius</persName></person><person xml:id="LORDS.0.3_Tim"><persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName></person><person xml:id="SERVANTS.TIMON.X.1_Tim"><persName>SERVANTS.TIMON.X.1_Tim</persName></person><person xml:id="Cupid_Tim"><persName>“Cupid” and other Maskers (as Amazons)</persName></person><person xml:id="FRIENDS.Lucius_Tim"><persName>Lucius</persName></person><person xml:id="LADIES.0.1_Tim"><persName>“Cupid” and other Maskers (as Amazons)</persName></person><person xml:id="LADIES_Tim"><persName>“Cupid” and other Maskers (as Amazons)</persName></person><person xml:id="Flavius_Tim"><persName>Flavius</persName></person><person xml:id="ATTENDANTS.TIMON.0.1_Tim"><persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName></person><person xml:id="SERVANTS.TIMON.1_Tim"><persName>SERVANTS.TIMON.1_Tim</persName></person><person xml:id="SERVANTS.TIMON.2_Tim"><persName>SERVANTS.TIMON.2_Tim</persName></person><person xml:id="SERVANTS.TIMON.3_Tim"><persName>SERVANTS.TIMON.3_Tim</persName></person><person xml:id="LORDS_Tim"><persName>Senators Lords</persName><persName>Senators Lords</persName></person><person xml:id="SENATORS.X_Tim"><persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName></person><person xml:id="SERVANTS.Caphis_Tim"><persName>Caphis</persName></person><person xml:id="SERVANTS.VARRO.1_Tim"><persName>servants of Timon’s creditors</persName></person><person xml:id="SERVANTS.ISIDORE.1_Tim"><persName>Isidore’s Man</persName></person><person xml:id="Fool_Tim"><persName>Fool</persName></person><person xml:id="SERVANTS.Page_Tim"><persName>Page</persName></person><person xml:id="SERVANTS.TIMON.Flaminius_Tim"><persName>Flaminius</persName></person><person xml:id="SERVANTS.TIMON.Servilius_Tim"><persName>Servilius</persName></person><person xml:id="SERVANTS.TIMON.X.2_Tim"><persName>SERVANTS.TIMON.X.2_Tim</persName></person><person xml:id="SERVANTS.LUCULLUS.1_Tim"><persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName></person><person xml:id="FRIENDS.Lucullus_Tim"><persName>Lucullus</persName></person><person xml:id="STRANGERS.1_Tim"><persName>STRANGERS.1_Tim</persName></person><person xml:id="STRANGERS.2_Tim"><persName>STRANGERS.2_Tim</persName></person><person xml:id="STRANGERS.3_Tim"><persName>STRANGERS.3_Tim</persName></person><person xml:id="FRIENDS.Sempronius_Tim"><persName>Sempronius</persName></person><person xml:id="SERVANTS.Titus_Tim"><persName>Titus</persName></person><person xml:id="SERVANTS.Hortensius_Tim"><persName>Hortensius</persName></person><person xml:id="SERVANTS.LUCIUS.1_Tim"><persName>Lucius’ Man</persName></person><person xml:id="SERVANTS.Philotus_Tim"><persName>Philotus</persName></person><person xml:id="SERVANTS.VARRO.2_Tim"><persName>servants of Timon’s creditors</persName></person><person xml:id="SENATORS.0.1_Tim"><persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName></person><person xml:id="SENATORS.0.2_Tim"><persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName></person><person xml:id="SENATORS.0.3_Tim"><persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName></person><person xml:id="FRIENDS.0.1_Tim"><persName>FRIENDS.0.1_Tim</persName></person><person xml:id="FRIENDS.0.2_Tim"><persName>FRIENDS.0.2_Tim</persName></person><person xml:id="FRIENDS.0.3_Tim"><persName>FRIENDS.0.3_Tim</persName></person><person xml:id="FRIENDS.0_Tim"><persName>FRIENDS.0_Tim</persName></person><person xml:id="FRIENDS.0.4_Tim"><persName>FRIENDS.0.4_Tim</persName></person><person xml:id="SERVANTS.TIMON.0.1_Tim"><persName>SERVANTS.TIMON.0.1_Tim</persName></person><person xml:id="SERVANTS.TIMON.0.2_Tim"><persName>SERVANTS.TIMON.0.2_Tim</persName></person><person xml:id="SERVANTS.TIMON.0.3_Tim"><persName>SERVANTS.TIMON.0.3_Tim</persName></person><person xml:id="Phrynia_Tim"><persName>Phrynia</persName></person><person xml:id="Timandra_Tim"><persName>Timandra</persName></person><person xml:id="BANDITS.1_Tim"><persName>BANDITS.1_Tim</persName></person><person xml:id="BANDITS.2_Tim"><persName>BANDITS.2_Tim</persName></person><person xml:id="BANDITS.3_Tim"><persName>BANDITS.3_Tim</persName></person><person xml:id="SENATORS.1_Tim"><persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName></person><person xml:id="SENATORS.2_Tim"><persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName></person><person xml:id="SENATORS.3_Tim"><persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName></person><person xml:id="MESSENGERS.X.3_Tim"><persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName></person><person xml:id="SENATORS.4_Tim"><persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName></person><person xml:id="SOLDIERS.1_Tim"><persName>Soldier</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Poet_Tim">
+            <persName>Poet</persName>
+          </person>
+          <person xml:id="Painter_Tim">
+            <persName>Painter</persName>
+          </person>
+          <person xml:id="Merchant_Tim">
+            <persName>Merchant</persName>
+          </person>
+          <person xml:id="Jeweler_Tim">
+            <persName>Jeweler</persName>
+          </person>
+          <person xml:id="Timon_Tim">
+            <persName>Timon</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.1_Tim">
+            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
+          </person>
+          <person xml:id="OldMan_Tim">
+            <persName>Old Athenian</persName>
+          </person>
+          <person xml:id="SERVANTS.TIMON.Lucilius_Tim">
+            <persName>Lucilius</persName>
+          </person>
+          <person xml:id="Apemantus_Tim">
+            <persName>Apemantus</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.2_Tim">
+            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
+          </person>
+          <person xml:id="Alcibiades_Tim">
+            <persName>Alcibiades</persName>
+          </person>
+          <person xml:id="LORDS.0.1_Tim">
+            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
+          </person>
+          <person xml:id="LORDS.0.2_Tim">
+            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
+          </person>
+          <person xml:id="FRIENDS.Ventidius_Tim">
+            <persName>Ventidius</persName>
+          </person>
+          <person xml:id="LORDS.0.3_Tim">
+            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
+          </person>
+          <person xml:id="SERVANTS.TIMON.X.1_Tim">
+            <persName>SERVANTS.TIMON.X.1_Tim</persName>
+          </person>
+          <person xml:id="Cupid_Tim">
+            <persName>“Cupid” and other Maskers (as Amazons)</persName>
+          </person>
+          <person xml:id="FRIENDS.Lucius_Tim">
+            <persName>Lucius</persName>
+          </person>
+          <person xml:id="LADIES.0.1_Tim">
+            <persName>“Cupid” and other Maskers (as Amazons)</persName>
+          </person>
+          <person xml:id="LADIES_Tim">
+            <persName>“Cupid” and other Maskers (as Amazons)</persName>
+          </person>
+          <person xml:id="Flavius_Tim">
+            <persName>Flavius</persName>
+          </person>
+          <person xml:id="ATTENDANTS.TIMON.0.1_Tim">
+            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
+          </person>
+          <person xml:id="SERVANTS.TIMON.1_Tim">
+            <persName>SERVANTS.TIMON.1_Tim</persName>
+          </person>
+          <person xml:id="SERVANTS.TIMON.2_Tim">
+            <persName>SERVANTS.TIMON.2_Tim</persName>
+          </person>
+          <person xml:id="SERVANTS.TIMON.3_Tim">
+            <persName>SERVANTS.TIMON.3_Tim</persName>
+          </person>
+          <person xml:id="LORDS_Tim">
+            <persName>Senators Lords</persName>
+            <persName>Senators Lords</persName>
+          </person>
+          <person xml:id="SENATORS.X_Tim">
+            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
+          </person>
+          <person xml:id="SERVANTS.Caphis_Tim">
+            <persName>Caphis</persName>
+          </person>
+          <person xml:id="SERVANTS.VARRO.1_Tim">
+            <persName>servants of Timon’s creditors</persName>
+          </person>
+          <person xml:id="SERVANTS.ISIDORE.1_Tim">
+            <persName>Isidore’s Man</persName>
+          </person>
+          <person xml:id="Fool_Tim">
+            <persName>Fool</persName>
+          </person>
+          <person xml:id="SERVANTS.Page_Tim">
+            <persName>Page</persName>
+          </person>
+          <person xml:id="SERVANTS.TIMON.Flaminius_Tim">
+            <persName>Flaminius</persName>
+          </person>
+          <person xml:id="SERVANTS.TIMON.Servilius_Tim">
+            <persName>Servilius</persName>
+          </person>
+          <person xml:id="SERVANTS.TIMON.X.2_Tim">
+            <persName>SERVANTS.TIMON.X.2_Tim</persName>
+          </person>
+          <person xml:id="SERVANTS.LUCULLUS.1_Tim">
+            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
+          </person>
+          <person xml:id="FRIENDS.Lucullus_Tim">
+            <persName>Lucullus</persName>
+          </person>
+          <person xml:id="STRANGERS.1_Tim">
+            <persName>STRANGERS.1_Tim</persName>
+          </person>
+          <person xml:id="STRANGERS.2_Tim">
+            <persName>STRANGERS.2_Tim</persName>
+          </person>
+          <person xml:id="STRANGERS.3_Tim">
+            <persName>STRANGERS.3_Tim</persName>
+          </person>
+          <person xml:id="FRIENDS.Sempronius_Tim">
+            <persName>Sempronius</persName>
+          </person>
+          <person xml:id="SERVANTS.Titus_Tim">
+            <persName>Titus</persName>
+          </person>
+          <person xml:id="SERVANTS.Hortensius_Tim">
+            <persName>Hortensius</persName>
+          </person>
+          <person xml:id="SERVANTS.LUCIUS.1_Tim">
+            <persName>Lucius’ Man</persName>
+          </person>
+          <person xml:id="SERVANTS.Philotus_Tim">
+            <persName>Philotus</persName>
+          </person>
+          <person xml:id="SERVANTS.VARRO.2_Tim">
+            <persName>servants of Timon’s creditors</persName>
+          </person>
+          <person xml:id="SENATORS.0.1_Tim">
+            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
+          </person>
+          <person xml:id="SENATORS.0.2_Tim">
+            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
+          </person>
+          <person xml:id="SENATORS.0.3_Tim">
+            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
+          </person>
+          <person xml:id="FRIENDS.0.1_Tim">
+            <persName>FRIENDS.0.1_Tim</persName>
+          </person>
+          <person xml:id="FRIENDS.0.2_Tim">
+            <persName>FRIENDS.0.2_Tim</persName>
+          </person>
+          <person xml:id="FRIENDS.0.3_Tim">
+            <persName>FRIENDS.0.3_Tim</persName>
+          </person>
+          <person xml:id="FRIENDS.0_Tim">
+            <persName>FRIENDS.0_Tim</persName>
+          </person>
+          <person xml:id="FRIENDS.0.4_Tim">
+            <persName>FRIENDS.0.4_Tim</persName>
+          </person>
+          <person xml:id="SERVANTS.TIMON.0.1_Tim">
+            <persName>SERVANTS.TIMON.0.1_Tim</persName>
+          </person>
+          <person xml:id="SERVANTS.TIMON.0.2_Tim">
+            <persName>SERVANTS.TIMON.0.2_Tim</persName>
+          </person>
+          <person xml:id="SERVANTS.TIMON.0.3_Tim">
+            <persName>SERVANTS.TIMON.0.3_Tim</persName>
+          </person>
+          <person xml:id="Phrynia_Tim">
+            <persName>Phrynia</persName>
+          </person>
+          <person xml:id="Timandra_Tim">
+            <persName>Timandra</persName>
+          </person>
+          <person xml:id="BANDITS.1_Tim">
+            <persName>BANDITS.1_Tim</persName>
+          </person>
+          <person xml:id="BANDITS.2_Tim">
+            <persName>BANDITS.2_Tim</persName>
+          </person>
+          <person xml:id="BANDITS.3_Tim">
+            <persName>BANDITS.3_Tim</persName>
+          </person>
+          <person xml:id="SENATORS.1_Tim">
+            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
+          </person>
+          <person xml:id="SENATORS.2_Tim">
+            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
+          </person>
+          <person xml:id="SENATORS.3_Tim">
+            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
+          </person>
+          <person xml:id="MESSENGERS.X.3_Tim">
+            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
+          </person>
+          <person xml:id="SENATORS.4_Tim">
+            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
+          </person>
+          <person xml:id="SOLDIERS.1_Tim">
+            <persName>Soldier</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/timon-of-athens.xml
+++ b/tei/timon-of-athens.xml
@@ -88,209 +88,209 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Poet_Tim">
+          <person xml:id="Poet_Tim" sex="MALE">
             <persName>Poet</persName>
           </person>
-          <person xml:id="Painter_Tim">
+          <person xml:id="Painter_Tim" sex="MALE">
             <persName>Painter</persName>
           </person>
-          <person xml:id="Merchant_Tim">
+          <person xml:id="Merchant_Tim" sex="MALE">
             <persName>Merchant</persName>
           </person>
-          <person xml:id="Jeweler_Tim">
+          <person xml:id="Jeweler_Tim" sex="MALE">
             <persName>Jeweler</persName>
           </person>
-          <person xml:id="Timon_Tim">
+          <person xml:id="Timon_Tim" ana="http://www.wikidata.org/entity/Q1747004">
             <persName>Timon</persName>
           </person>
-          <person xml:id="MESSENGERS.X.1_Tim">
-            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
-          </person>
-          <person xml:id="OldMan_Tim">
+          <personGrp xml:id="MESSENGERS.X.1_Tim" sex="UNKNOWN">
+            <name>Soldiers, Servants, Messengers, Attendants, Musicians</name>
+          </personGrp>
+          <person xml:id="OldMan_Tim" sex="MALE">
             <persName>Old Athenian</persName>
           </person>
-          <person xml:id="SERVANTS.TIMON.Lucilius_Tim">
+          <person xml:id="SERVANTS.TIMON.Lucilius_Tim" sex="MALE">
             <persName>Lucilius</persName>
           </person>
-          <person xml:id="Apemantus_Tim">
+          <person xml:id="Apemantus_Tim" sex="MALE">
             <persName>Apemantus</persName>
           </person>
-          <person xml:id="MESSENGERS.X.2_Tim">
-            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
-          </person>
-          <person xml:id="Alcibiades_Tim">
+          <personGrp xml:id="MESSENGERS.X.2_Tim" sex="UNKNOWN">
+            <name>Soldiers, Servants, Messengers, Attendants, Musicians</name>
+          </personGrp>
+          <person xml:id="Alcibiades_Tim" ana="http://www.wikidata.org/entity/Q187982">
             <persName>Alcibiades</persName>
           </person>
-          <person xml:id="LORDS.0.1_Tim">
-            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
-          </person>
-          <person xml:id="LORDS.0.2_Tim">
-            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
-          </person>
-          <person xml:id="FRIENDS.Ventidius_Tim">
+          <personGrp xml:id="LORDS.0.1_Tim" sex="UNKNOWN">
+            <name>Soldiers, Servants, Messengers, Attendants, Musicians</name>
+          </personGrp>
+          <personGrp xml:id="LORDS.0.2_Tim" sex="UNKNOWN">
+            <name>Soldiers, Servants, Messengers, Attendants, Musicians</name>
+          </personGrp>
+          <person xml:id="FRIENDS.Ventidius_Tim" sex="MALE">
             <persName>Ventidius</persName>
           </person>
-          <person xml:id="LORDS.0.3_Tim">
-            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
-          </person>
-          <person xml:id="SERVANTS.TIMON.X.1_Tim">
+          <personGrp xml:id="LORDS.0.3_Tim" sex="UNKNOWN">
+            <name>Soldiers, Servants, Messengers, Attendants, Musicians</name>
+          </personGrp>
+          <person xml:id="SERVANTS.TIMON.X.1_Tim" sex="MALE">
             <persName>SERVANTS.TIMON.X.1_Tim</persName>
           </person>
-          <person xml:id="Cupid_Tim">
-            <persName>“Cupid” and other Maskers (as Amazons)</persName>
-          </person>
-          <person xml:id="FRIENDS.Lucius_Tim">
+          <personGrp xml:id="Cupid_Tim" sex="UNKNOWN">
+            <name>“Cupid” and other Maskers (as Amazons)</name>
+          </personGrp>
+          <person xml:id="FRIENDS.Lucius_Tim" sex="MALE">
             <persName>Lucius</persName>
           </person>
-          <person xml:id="LADIES.0.1_Tim">
-            <persName>“Cupid” and other Maskers (as Amazons)</persName>
-          </person>
-          <person xml:id="LADIES_Tim">
-            <persName>“Cupid” and other Maskers (as Amazons)</persName>
-          </person>
-          <person xml:id="Flavius_Tim">
+          <personGrp xml:id="LADIES.0.1_Tim" sex="UNKNOWN">
+            <name>“Cupid” and other Maskers (as Amazons)</name>
+          </personGrp>
+          <personGrp xml:id="LADIES_Tim" sex="UNKNOWN">
+            <name>“Cupid” and other Maskers (as Amazons)</name>
+          </personGrp>
+          <person xml:id="Flavius_Tim" sex="MALE">
             <persName>Flavius</persName>
           </person>
-          <person xml:id="ATTENDANTS.TIMON.0.1_Tim">
-            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
-          </person>
-          <person xml:id="SERVANTS.TIMON.1_Tim">
+          <personGrp xml:id="ATTENDANTS.TIMON.0.1_Tim" sex="UNKNOWN">
+            <name>Soldiers, Servants, Messengers, Attendants, Musicians</name>
+          </personGrp>
+          <person xml:id="SERVANTS.TIMON.1_Tim" sex="MALE">
             <persName>SERVANTS.TIMON.1_Tim</persName>
           </person>
-          <person xml:id="SERVANTS.TIMON.2_Tim">
+          <person xml:id="SERVANTS.TIMON.2_Tim" sex="MALE">
             <persName>SERVANTS.TIMON.2_Tim</persName>
           </person>
-          <person xml:id="SERVANTS.TIMON.3_Tim">
+          <person xml:id="SERVANTS.TIMON.3_Tim" sex="MALE">
             <persName>SERVANTS.TIMON.3_Tim</persName>
           </person>
-          <person xml:id="LORDS_Tim">
-            <persName>Senators Lords</persName>
-            <persName>Senators Lords</persName>
-          </person>
-          <person xml:id="SENATORS.X_Tim">
-            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
-          </person>
-          <person xml:id="SERVANTS.Caphis_Tim">
+          <personGrp xml:id="LORDS_Tim" sex="UNKNOWN">
+            <name>Senators Lords</name>
+            <name>Senators Lords</name>
+          </personGrp>
+          <personGrp xml:id="SENATORS.X_Tim" sex="UNKNOWN">
+            <name>Soldiers, Servants, Messengers, Attendants, Musicians</name>
+          </personGrp>
+          <person xml:id="SERVANTS.Caphis_Tim" sex="MALE">
             <persName>Caphis</persName>
           </person>
-          <person xml:id="SERVANTS.VARRO.1_Tim">
-            <persName>servants of Timon’s creditors</persName>
-          </person>
-          <person xml:id="SERVANTS.ISIDORE.1_Tim">
+          <personGrp xml:id="SERVANTS.VARRO.1_Tim" sex="UNKNOWN">
+            <name>servants of Timon’s creditors</name>
+          </personGrp>
+          <person xml:id="SERVANTS.ISIDORE.1_Tim" sex="MALE">
             <persName>Isidore’s Man</persName>
           </person>
-          <person xml:id="Fool_Tim">
+          <person xml:id="Fool_Tim" sex="MALE">
             <persName>Fool</persName>
           </person>
-          <person xml:id="SERVANTS.Page_Tim">
+          <person xml:id="SERVANTS.Page_Tim" sex="MALE">
             <persName>Page</persName>
           </person>
-          <person xml:id="SERVANTS.TIMON.Flaminius_Tim">
+          <person xml:id="SERVANTS.TIMON.Flaminius_Tim" sex="MALE">
             <persName>Flaminius</persName>
           </person>
-          <person xml:id="SERVANTS.TIMON.Servilius_Tim">
+          <person xml:id="SERVANTS.TIMON.Servilius_Tim" sex="MALE">
             <persName>Servilius</persName>
           </person>
-          <person xml:id="SERVANTS.TIMON.X.2_Tim">
+          <person xml:id="SERVANTS.TIMON.X.2_Tim" sex="MALE">
             <persName>SERVANTS.TIMON.X.2_Tim</persName>
           </person>
-          <person xml:id="SERVANTS.LUCULLUS.1_Tim">
-            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
-          </person>
-          <person xml:id="FRIENDS.Lucullus_Tim">
+          <personGrp xml:id="SERVANTS.LUCULLUS.1_Tim" sex="UNKNOWN">
+            <name>Soldiers, Servants, Messengers, Attendants, Musicians</name>
+          </personGrp>
+          <person xml:id="FRIENDS.Lucullus_Tim" sex="MALE">
             <persName>Lucullus</persName>
           </person>
-          <person xml:id="STRANGERS.1_Tim">
+          <person xml:id="STRANGERS.1_Tim" sex="MALE">
             <persName>STRANGERS.1_Tim</persName>
           </person>
-          <person xml:id="STRANGERS.2_Tim">
+          <person xml:id="STRANGERS.2_Tim" sex="MALE">
             <persName>STRANGERS.2_Tim</persName>
           </person>
-          <person xml:id="STRANGERS.3_Tim">
+          <person xml:id="STRANGERS.3_Tim" sex="MALE">
             <persName>STRANGERS.3_Tim</persName>
           </person>
-          <person xml:id="FRIENDS.Sempronius_Tim">
+          <person xml:id="FRIENDS.Sempronius_Tim" sex="MALE">
             <persName>Sempronius</persName>
           </person>
-          <person xml:id="SERVANTS.Titus_Tim">
+          <person xml:id="SERVANTS.Titus_Tim" sex="MALE">
             <persName>Titus</persName>
           </person>
-          <person xml:id="SERVANTS.Hortensius_Tim">
+          <person xml:id="SERVANTS.Hortensius_Tim" sex="MALE">
             <persName>Hortensius</persName>
           </person>
-          <person xml:id="SERVANTS.LUCIUS.1_Tim">
+          <person xml:id="SERVANTS.LUCIUS.1_Tim" sex="MALE">
             <persName>Lucius’ Man</persName>
           </person>
-          <person xml:id="SERVANTS.Philotus_Tim">
+          <person xml:id="SERVANTS.Philotus_Tim" sex="MALE">
             <persName>Philotus</persName>
           </person>
-          <person xml:id="SERVANTS.VARRO.2_Tim">
-            <persName>servants of Timon’s creditors</persName>
-          </person>
-          <person xml:id="SENATORS.0.1_Tim">
-            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
-          </person>
-          <person xml:id="SENATORS.0.2_Tim">
-            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
-          </person>
-          <person xml:id="SENATORS.0.3_Tim">
-            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
-          </person>
-          <person xml:id="FRIENDS.0.1_Tim">
+          <personGrp xml:id="SERVANTS.VARRO.2_Tim" sex="UNKNOWN">
+            <name>servants of Timon’s creditors</name>
+          </personGrp>
+          <personGrp xml:id="SENATORS.0.1_Tim" sex="UNKNOWN">
+            <name>Soldiers, Servants, Messengers, Attendants, Musicians</name>
+          </personGrp>
+          <personGrp xml:id="SENATORS.0.2_Tim" sex="UNKNOWN">
+            <name>Soldiers, Servants, Messengers, Attendants, Musicians</name>
+          </personGrp>
+          <personGrp xml:id="SENATORS.0.3_Tim" sex="UNKNOWN">
+            <name>Soldiers, Servants, Messengers, Attendants, Musicians</name>
+          </personGrp>
+          <person xml:id="FRIENDS.0.1_Tim" sex="MALE">
             <persName>FRIENDS.0.1_Tim</persName>
           </person>
-          <person xml:id="FRIENDS.0.2_Tim">
+          <person xml:id="FRIENDS.0.2_Tim" sex="MALE">
             <persName>FRIENDS.0.2_Tim</persName>
           </person>
-          <person xml:id="FRIENDS.0.3_Tim">
+          <person xml:id="FRIENDS.0.3_Tim" sex="MALE">
             <persName>FRIENDS.0.3_Tim</persName>
           </person>
-          <person xml:id="FRIENDS.0_Tim">
+          <person xml:id="FRIENDS.0_Tim" sex="MALE">
             <persName>FRIENDS.0_Tim</persName>
           </person>
-          <person xml:id="FRIENDS.0.4_Tim">
+          <person xml:id="FRIENDS.0.4_Tim" sex="MALE">
             <persName>FRIENDS.0.4_Tim</persName>
           </person>
-          <person xml:id="SERVANTS.TIMON.0.1_Tim">
+          <person xml:id="SERVANTS.TIMON.0.1_Tim" sex="MALE">
             <persName>SERVANTS.TIMON.0.1_Tim</persName>
           </person>
-          <person xml:id="SERVANTS.TIMON.0.2_Tim">
+          <person xml:id="SERVANTS.TIMON.0.2_Tim" sex="MALE">
             <persName>SERVANTS.TIMON.0.2_Tim</persName>
           </person>
-          <person xml:id="SERVANTS.TIMON.0.3_Tim">
+          <person xml:id="SERVANTS.TIMON.0.3_Tim" sex="MALE">
             <persName>SERVANTS.TIMON.0.3_Tim</persName>
           </person>
-          <person xml:id="Phrynia_Tim">
+          <person xml:id="Phrynia_Tim" sex="FEMALE">
             <persName>Phrynia</persName>
           </person>
-          <person xml:id="Timandra_Tim">
+          <person xml:id="Timandra_Tim" sex="FEMALE">
             <persName>Timandra</persName>
           </person>
-          <person xml:id="BANDITS.1_Tim">
+          <person xml:id="BANDITS.1_Tim" sex="MALE">
             <persName>BANDITS.1_Tim</persName>
           </person>
-          <person xml:id="BANDITS.2_Tim">
+          <person xml:id="BANDITS.2_Tim" sex="MALE">
             <persName>BANDITS.2_Tim</persName>
           </person>
-          <person xml:id="BANDITS.3_Tim">
+          <person xml:id="BANDITS.3_Tim" sex="MALE">
             <persName>BANDITS.3_Tim</persName>
           </person>
-          <person xml:id="SENATORS.1_Tim">
-            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
-          </person>
-          <person xml:id="SENATORS.2_Tim">
-            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
-          </person>
-          <person xml:id="SENATORS.3_Tim">
-            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
-          </person>
-          <person xml:id="MESSENGERS.X.3_Tim">
-            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
-          </person>
-          <person xml:id="SENATORS.4_Tim">
-            <persName>Soldiers, Servants, Messengers, Attendants, Musicians</persName>
-          </person>
-          <person xml:id="SOLDIERS.1_Tim">
+          <personGrp xml:id="SENATORS.1_Tim" sex="UNKNOWN">
+            <name>Soldiers, Servants, Messengers, Attendants, Musicians</name>
+          </personGrp>
+          <personGrp xml:id="SENATORS.2_Tim" sex="UNKNOWN">
+            <name>Soldiers, Servants, Messengers, Attendants, Musicians</name>
+          </personGrp>
+          <personGrp xml:id="SENATORS.3_Tim" sex="UNKNOWN">
+            <name>Soldiers, Servants, Messengers, Attendants, Musicians</name>
+          </personGrp>
+          <personGrp xml:id="MESSENGERS.X.3_Tim" sex="UNKNOWN">
+            <name>Soldiers, Servants, Messengers, Attendants, Musicians</name>
+          </personGrp>
+          <personGrp xml:id="SENATORS.4_Tim" sex="UNKNOWN">
+            <name>Soldiers, Servants, Messengers, Attendants, Musicians</name>
+          </personGrp>
+          <person xml:id="SOLDIERS.1_Tim" sex="MALE">
             <persName>Soldier</persName>
           </person>
         </listPerson>

--- a/tei/titus-andronicus.xml
+++ b/tei/titus-andronicus.xml
@@ -88,87 +88,87 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Saturninus_Tit">
+          <person xml:id="Saturninus_Tit" sex="MALE">
             <persName>Saturninus</persName>
           </person>
-          <person xml:id="Bassianus_Tit">
+          <person xml:id="Bassianus_Tit" sex="MALE">
             <persName>Bassianus</persName>
           </person>
-          <person xml:id="Marcus_Tit">
+          <person xml:id="Marcus_Tit" sex="MALE">
             <persName>Marcus Andronicus</persName>
           </person>
-          <person xml:id="Captain_Tit">
+          <person xml:id="Captain_Tit" sex="MALE">
             <persName>Captain</persName>
           </person>
-          <person xml:id="Titus_Tit">
+          <person xml:id="Titus_Tit" sex="MALE">
             <persName>Titus Andronicus</persName>
           </person>
-          <person xml:id="Lucius_Tit">
+          <person xml:id="Lucius_Tit" sex="MALE">
             <persName>Lucius</persName>
           </person>
-          <person xml:id="Tamora_Tit">
+          <person xml:id="Tamora_Tit" sex="FEMALE">
             <persName>Tamora</persName>
           </person>
-          <person xml:id="Chiron_Tit">
+          <person xml:id="Chiron_Tit" sex="MALE">
             <persName>Chiron</persName>
           </person>
-          <person xml:id="Demetrius_Tit">
+          <person xml:id="Demetrius_Tit" sex="MALE">
             <persName>Demetrius</persName>
           </person>
-          <person xml:id="Lavinia_Tit">
+          <person xml:id="Lavinia_Tit" sex="FEMALE">
             <persName>Lavinia</persName>
           </person>
-          <person xml:id="TRIBUNES_Tit">
-            <persName>Tribunes, Senators, Romans, Goths, Drummers, Trumpeters, Soldiers, Guards, Attendants, a black Child</persName>
-          </person>
-          <person xml:id="Mutius_Tit">
+          <personGrp xml:id="TRIBUNES_Tit" sex="UNKNOWN">
+            <name>Tribunes, Senators, Romans, Goths, Drummers, Trumpeters, Soldiers, Guards, Attendants, a black Child</name>
+          </personGrp>
+          <person xml:id="Mutius_Tit" sex="MALE">
             <persName>Mutius</persName>
           </person>
-          <person xml:id="Martius_Tit">
+          <person xml:id="Martius_Tit" sex="MALE">
             <persName>Martius</persName>
           </person>
-          <person xml:id="Quintus_Tit">
+          <person xml:id="Quintus_Tit" sex="MALE">
             <persName>Quintus</persName>
           </person>
-          <person xml:id="Aaron_Tit">
+          <person xml:id="Aaron_Tit" sex="MALE">
             <persName>Aaron</persName>
           </person>
-          <person xml:id="Messenger_Tit">
+          <person xml:id="Messenger_Tit" sex="MALE">
             <persName>Messenger</persName>
           </person>
-          <person xml:id="YoungLucius_Tit">
+          <person xml:id="YoungLucius_Tit" sex="MALE">
             <persName>Young Lucius</persName>
           </person>
-          <person xml:id="Nurse_Tit">
+          <person xml:id="Nurse_Tit" sex="FEMALE">
             <persName>Nurse</persName>
           </person>
-          <person xml:id="Publius_Tit">
+          <person xml:id="Publius_Tit" sex="MALE">
             <persName>Publius</persName>
           </person>
-          <person xml:id="CountryFellow_Tit">
+          <person xml:id="CountryFellow_Tit" sex="MALE">
             <persName>Country Fellow</persName>
           </person>
-          <person xml:id="Aemilius_Tit">
+          <person xml:id="Aemilius_Tit" sex="MALE">
             <persName>Aemilius</persName>
           </person>
-          <person xml:id="GOTHS.0.1_Tit">
+          <person xml:id="GOTHS.0.1_Tit" sex="MALE">
             <persName>First Goth</persName>
           </person>
-          <person xml:id="GOTHS_Tit">
-            <persName>Tribunes, Senators, Romans, Goths, Drummers, Trumpeters, Soldiers, Guards, Attendants, a black Child</persName>
-          </person>
-          <person xml:id="GOTHS.0.2_Tit">
+          <personGrp xml:id="GOTHS_Tit" sex="UNKNOWN">
+            <name>Tribunes, Senators, Romans, Goths, Drummers, Trumpeters, Soldiers, Guards, Attendants, a black Child</name>
+          </personGrp>
+          <person xml:id="GOTHS.0.2_Tit" sex="MALE">
             <persName>Second Goth</persName>
           </person>
-          <person xml:id="GOTHS.0_Tit">
-            <persName>Tribunes, Senators, Romans, Goths, Drummers, Trumpeters, Soldiers, Guards, Attendants, a black Child</persName>
-          </person>
-          <person xml:id="ATTENDANTS_Tit">
-            <persName>Tribunes, Senators, Romans, Goths, Drummers, Trumpeters, Soldiers, Guards, Attendants, a black Child</persName>
-          </person>
-          <person xml:id="TRIBUNES.0.1_Tit">
-            <persName>Tribunes, Senators, Romans, Goths, Drummers, Trumpeters, Soldiers, Guards, Attendants, a black Child</persName>
-          </person>
+          <personGrp xml:id="GOTHS.0_Tit" sex="UNKNOWN">
+            <name>Tribunes, Senators, Romans, Goths, Drummers, Trumpeters, Soldiers, Guards, Attendants, a black Child</name>
+          </personGrp>
+          <personGrp xml:id="ATTENDANTS_Tit" sex="UNKNOWN">
+            <name>Tribunes, Senators, Romans, Goths, Drummers, Trumpeters, Soldiers, Guards, Attendants, a black Child</name>
+          </personGrp>
+          <personGrp xml:id="TRIBUNES.0.1_Tit" sex="UNKNOWN">
+            <name>Tribunes, Senators, Romans, Goths, Drummers, Trumpeters, Soldiers, Guards, Attendants, a black Child</name>
+          </personGrp>
         </listPerson>
       </particDesc>
     </profileDesc>

--- a/tei/titus-andronicus.xml
+++ b/tei/titus-andronicus.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,92 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Saturninus_Tit"><persName>Saturninus</persName></person><person xml:id="Bassianus_Tit"><persName>Bassianus</persName></person><person xml:id="Marcus_Tit"><persName>Marcus Andronicus</persName></person><person xml:id="Captain_Tit"><persName>Captain</persName></person><person xml:id="Titus_Tit"><persName>Titus Andronicus</persName></person><person xml:id="Lucius_Tit"><persName>Lucius</persName></person><person xml:id="Tamora_Tit"><persName>Tamora</persName></person><person xml:id="Chiron_Tit"><persName>Chiron</persName></person><person xml:id="Demetrius_Tit"><persName>Demetrius</persName></person><person xml:id="Lavinia_Tit"><persName>Lavinia</persName></person><person xml:id="TRIBUNES_Tit"><persName>Tribunes, Senators, Romans, Goths, Drummers, Trumpeters, Soldiers, Guards, Attendants, a black Child</persName></person><person xml:id="Mutius_Tit"><persName>Mutius</persName></person><person xml:id="Martius_Tit"><persName>Martius</persName></person><person xml:id="Quintus_Tit"><persName>Quintus</persName></person><person xml:id="Aaron_Tit"><persName>Aaron</persName></person><person xml:id="Messenger_Tit"><persName>Messenger</persName></person><person xml:id="YoungLucius_Tit"><persName>Young Lucius</persName></person><person xml:id="Nurse_Tit"><persName>Nurse</persName></person><person xml:id="Publius_Tit"><persName>Publius</persName></person><person xml:id="CountryFellow_Tit"><persName>Country Fellow</persName></person><person xml:id="Aemilius_Tit"><persName>Aemilius</persName></person><person xml:id="GOTHS.0.1_Tit"><persName>First Goth</persName></person><person xml:id="GOTHS_Tit"><persName>Tribunes, Senators, Romans, Goths, Drummers, Trumpeters, Soldiers, Guards, Attendants, a black Child</persName></person><person xml:id="GOTHS.0.2_Tit"><persName>Second Goth</persName></person><person xml:id="GOTHS.0_Tit"><persName>Tribunes, Senators, Romans, Goths, Drummers, Trumpeters, Soldiers, Guards, Attendants, a black Child</persName></person><person xml:id="ATTENDANTS_Tit"><persName>Tribunes, Senators, Romans, Goths, Drummers, Trumpeters, Soldiers, Guards, Attendants, a black Child</persName></person><person xml:id="TRIBUNES.0.1_Tit"><persName>Tribunes, Senators, Romans, Goths, Drummers, Trumpeters, Soldiers, Guards, Attendants, a black Child</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Saturninus_Tit">
+            <persName>Saturninus</persName>
+          </person>
+          <person xml:id="Bassianus_Tit">
+            <persName>Bassianus</persName>
+          </person>
+          <person xml:id="Marcus_Tit">
+            <persName>Marcus Andronicus</persName>
+          </person>
+          <person xml:id="Captain_Tit">
+            <persName>Captain</persName>
+          </person>
+          <person xml:id="Titus_Tit">
+            <persName>Titus Andronicus</persName>
+          </person>
+          <person xml:id="Lucius_Tit">
+            <persName>Lucius</persName>
+          </person>
+          <person xml:id="Tamora_Tit">
+            <persName>Tamora</persName>
+          </person>
+          <person xml:id="Chiron_Tit">
+            <persName>Chiron</persName>
+          </person>
+          <person xml:id="Demetrius_Tit">
+            <persName>Demetrius</persName>
+          </person>
+          <person xml:id="Lavinia_Tit">
+            <persName>Lavinia</persName>
+          </person>
+          <person xml:id="TRIBUNES_Tit">
+            <persName>Tribunes, Senators, Romans, Goths, Drummers, Trumpeters, Soldiers, Guards, Attendants, a black Child</persName>
+          </person>
+          <person xml:id="Mutius_Tit">
+            <persName>Mutius</persName>
+          </person>
+          <person xml:id="Martius_Tit">
+            <persName>Martius</persName>
+          </person>
+          <person xml:id="Quintus_Tit">
+            <persName>Quintus</persName>
+          </person>
+          <person xml:id="Aaron_Tit">
+            <persName>Aaron</persName>
+          </person>
+          <person xml:id="Messenger_Tit">
+            <persName>Messenger</persName>
+          </person>
+          <person xml:id="YoungLucius_Tit">
+            <persName>Young Lucius</persName>
+          </person>
+          <person xml:id="Nurse_Tit">
+            <persName>Nurse</persName>
+          </person>
+          <person xml:id="Publius_Tit">
+            <persName>Publius</persName>
+          </person>
+          <person xml:id="CountryFellow_Tit">
+            <persName>Country Fellow</persName>
+          </person>
+          <person xml:id="Aemilius_Tit">
+            <persName>Aemilius</persName>
+          </person>
+          <person xml:id="GOTHS.0.1_Tit">
+            <persName>First Goth</persName>
+          </person>
+          <person xml:id="GOTHS_Tit">
+            <persName>Tribunes, Senators, Romans, Goths, Drummers, Trumpeters, Soldiers, Guards, Attendants, a black Child</persName>
+          </person>
+          <person xml:id="GOTHS.0.2_Tit">
+            <persName>Second Goth</persName>
+          </person>
+          <person xml:id="GOTHS.0_Tit">
+            <persName>Tribunes, Senators, Romans, Goths, Drummers, Trumpeters, Soldiers, Guards, Attendants, a black Child</persName>
+          </person>
+          <person xml:id="ATTENDANTS_Tit">
+            <persName>Tribunes, Senators, Romans, Goths, Drummers, Trumpeters, Soldiers, Guards, Attendants, a black Child</persName>
+          </person>
+          <person xml:id="TRIBUNES.0.1_Tit">
+            <persName>Tribunes, Senators, Romans, Goths, Drummers, Trumpeters, Soldiers, Guards, Attendants, a black Child</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/troilus-and-cressida.xml
+++ b/tei/troilus-and-cressida.xml
@@ -70,7 +70,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -87,7 +87,113 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Prologue_Tro"><persName>Prologue</persName></person><person xml:id="Troilus_Tro"><persName>Troilus</persName></person><person xml:id="Pandarus_Tro"><persName>Pandarus</persName></person><person xml:id="Aeneas_Tro"><persName>Aeneas</persName></person><person xml:id="Cressida_Tro"><persName>Cressida</persName></person><person xml:id="Alexander_Tro"><persName>Alexander</persName></person><person xml:id="Boy_Tro"><persName>Troilus’s Boy</persName></person><person xml:id="Agamemnon_Tro"><persName>Agamemnon</persName></person><person xml:id="Nestor_Tro"><persName>Nestor</persName></person><person xml:id="Ulysses_Tro"><persName>Ulysses</persName></person><person xml:id="Menelaus_Tro"><persName>Menelaus</persName></person><person xml:id="Ajax_Tro"><persName>Ajax</persName></person><person xml:id="Thersites_Tro"><persName>Thersites</persName></person><person xml:id="Achilles_Tro"><persName>Achilles</persName></person><person xml:id="Patroclus_Tro"><persName>Patroclus</persName></person><person xml:id="Priam_Tro"><persName>Priam</persName></person><person xml:id="Hector_Tro"><persName>Hector</persName></person><person xml:id="Helenus_Tro"><persName>Helenus</persName></person><person xml:id="Cassandra_Tro"><persName>Cassandra</persName></person><person xml:id="Paris_Tro"><persName>Paris</persName></person><person xml:id="Diomedes_Tro"><persName>Diomedes</persName></person><person xml:id="SERVANTS.PARIS.1_Tro"><persName>Paris’s Servingman</persName></person><person xml:id="Helen_Tro"><persName>Helen</persName></person><person xml:id="SERVANTS.TROILUS.1_Tro"><persName>Troilus’s Man</persName></person><person xml:id="Calchas_Tro"><persName>Calchas</persName></person><person xml:id="Deiphobus_Tro"><persName>Deiphobus</persName></person><person xml:id="ATTENDANTS.GREEK_Tro"><persName>Other Trojans and Greeks, Common Soldiers of Troy and Greece, Trumpeters, Attendants, Torchbearers</persName></person><person xml:id="Andromache_Tro"><persName>Andromache</persName></person><person xml:id="SERVANTS.DIOMEDES.1_Tro"><persName>Diomedes’ Servingman</persName></person><person xml:id="Bastard_Tro"><persName>Bastard</persName></person><person xml:id="MYRMIDONS.0.1_Tro"><persName>MYRMIDONS.0.1_Tro</persName></person><person xml:id="SOLDIERS_Tro"><persName>Other Trojans and Greeks, Common Soldiers of Troy and Greece, Trumpeters, Attendants, Torchbearers</persName></person><person xml:id="Antenor_Tro"><persName>Antenor</persName></person><person xml:id="SOLDIERS.TROJAN_Tro"><persName>Other Trojans and Greeks, Common Soldiers of Troy and Greece, Trumpeters, Attendants, Torchbearers</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Prologue_Tro">
+            <persName>Prologue</persName>
+          </person>
+          <person xml:id="Troilus_Tro">
+            <persName>Troilus</persName>
+          </person>
+          <person xml:id="Pandarus_Tro">
+            <persName>Pandarus</persName>
+          </person>
+          <person xml:id="Aeneas_Tro">
+            <persName>Aeneas</persName>
+          </person>
+          <person xml:id="Cressida_Tro">
+            <persName>Cressida</persName>
+          </person>
+          <person xml:id="Alexander_Tro">
+            <persName>Alexander</persName>
+          </person>
+          <person xml:id="Boy_Tro">
+            <persName>Troilus’s Boy</persName>
+          </person>
+          <person xml:id="Agamemnon_Tro">
+            <persName>Agamemnon</persName>
+          </person>
+          <person xml:id="Nestor_Tro">
+            <persName>Nestor</persName>
+          </person>
+          <person xml:id="Ulysses_Tro">
+            <persName>Ulysses</persName>
+          </person>
+          <person xml:id="Menelaus_Tro">
+            <persName>Menelaus</persName>
+          </person>
+          <person xml:id="Ajax_Tro">
+            <persName>Ajax</persName>
+          </person>
+          <person xml:id="Thersites_Tro">
+            <persName>Thersites</persName>
+          </person>
+          <person xml:id="Achilles_Tro">
+            <persName>Achilles</persName>
+          </person>
+          <person xml:id="Patroclus_Tro">
+            <persName>Patroclus</persName>
+          </person>
+          <person xml:id="Priam_Tro">
+            <persName>Priam</persName>
+          </person>
+          <person xml:id="Hector_Tro">
+            <persName>Hector</persName>
+          </person>
+          <person xml:id="Helenus_Tro">
+            <persName>Helenus</persName>
+          </person>
+          <person xml:id="Cassandra_Tro">
+            <persName>Cassandra</persName>
+          </person>
+          <person xml:id="Paris_Tro">
+            <persName>Paris</persName>
+          </person>
+          <person xml:id="Diomedes_Tro">
+            <persName>Diomedes</persName>
+          </person>
+          <person xml:id="SERVANTS.PARIS.1_Tro">
+            <persName>Paris’s Servingman</persName>
+          </person>
+          <person xml:id="Helen_Tro">
+            <persName>Helen</persName>
+          </person>
+          <person xml:id="SERVANTS.TROILUS.1_Tro">
+            <persName>Troilus’s Man</persName>
+          </person>
+          <person xml:id="Calchas_Tro">
+            <persName>Calchas</persName>
+          </person>
+          <person xml:id="Deiphobus_Tro">
+            <persName>Deiphobus</persName>
+          </person>
+          <person xml:id="ATTENDANTS.GREEK_Tro">
+            <persName>Other Trojans and Greeks, Common Soldiers of Troy and Greece, Trumpeters, Attendants, Torchbearers</persName>
+          </person>
+          <person xml:id="Andromache_Tro">
+            <persName>Andromache</persName>
+          </person>
+          <person xml:id="SERVANTS.DIOMEDES.1_Tro">
+            <persName>Diomedes’ Servingman</persName>
+          </person>
+          <person xml:id="Bastard_Tro">
+            <persName>Bastard</persName>
+          </person>
+          <person xml:id="MYRMIDONS.0.1_Tro">
+            <persName>MYRMIDONS.0.1_Tro</persName>
+          </person>
+          <person xml:id="SOLDIERS_Tro">
+            <persName>Other Trojans and Greeks, Common Soldiers of Troy and Greece, Trumpeters, Attendants, Torchbearers</persName>
+          </person>
+          <person xml:id="Antenor_Tro">
+            <persName>Antenor</persName>
+          </person>
+          <person xml:id="SOLDIERS.TROJAN_Tro">
+            <persName>Other Trojans and Greeks, Common Soldiers of Troy and Greece, Trumpeters, Attendants, Torchbearers</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/troilus-and-cressida.xml
+++ b/tei/troilus-and-cressida.xml
@@ -89,108 +89,108 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Prologue_Tro">
+          <person xml:id="Prologue_Tro" sex="UNKNOWN">
             <persName>Prologue</persName>
           </person>
-          <person xml:id="Troilus_Tro">
+          <person xml:id="Troilus_Tro" ana="http://www.wikidata.org/entity/Q867342">
             <persName>Troilus</persName>
           </person>
-          <person xml:id="Pandarus_Tro">
+          <person xml:id="Pandarus_Tro" ana="http://www.wikidata.org/entity/Q1057384">
             <persName>Pandarus</persName>
           </person>
-          <person xml:id="Aeneas_Tro">
+          <person xml:id="Aeneas_Tro" ana="http://www.wikidata.org/entity/Q82732">
             <persName>Aeneas</persName>
           </person>
-          <person xml:id="Cressida_Tro">
+          <person xml:id="Cressida_Tro" sex="FEMALE">
             <persName>Cressida</persName>
           </person>
-          <person xml:id="Alexander_Tro">
+          <person xml:id="Alexander_Tro" sex="MALE">
             <persName>Alexander</persName>
           </person>
-          <person xml:id="Boy_Tro">
+          <person xml:id="Boy_Tro" sex="MALE">
             <persName>Troilus’s Boy</persName>
           </person>
-          <person xml:id="Agamemnon_Tro">
+          <person xml:id="Agamemnon_Tro" ana="http://www.wikidata.org/entity/Q128176">
             <persName>Agamemnon</persName>
           </person>
-          <person xml:id="Nestor_Tro">
+          <person xml:id="Nestor_Tro" ana="http://www.wikidata.org/entity/Q193267">
             <persName>Nestor</persName>
           </person>
-          <person xml:id="Ulysses_Tro">
+          <person xml:id="Ulysses_Tro" sex="MALE">
             <persName>Ulysses</persName>
           </person>
-          <person xml:id="Menelaus_Tro">
+          <person xml:id="Menelaus_Tro" ana="http://www.wikidata.org/entity/Q171839">
             <persName>Menelaus</persName>
           </person>
-          <person xml:id="Ajax_Tro">
+          <person xml:id="Ajax_Tro" ana="http://www.wikidata.org/entity/Q172725">
             <persName>Ajax</persName>
           </person>
-          <person xml:id="Thersites_Tro">
+          <person xml:id="Thersites_Tro" ana="http://www.wikidata.org/entity/Q1045730">
             <persName>Thersites</persName>
           </person>
-          <person xml:id="Achilles_Tro">
+          <person xml:id="Achilles_Tro" ana="http://www.wikidata.org/entity/Q41746">
             <persName>Achilles</persName>
           </person>
-          <person xml:id="Patroclus_Tro">
+          <person xml:id="Patroclus_Tro" ana="http://www.wikidata.org/entity/Q186271">
             <persName>Patroclus</persName>
           </person>
-          <person xml:id="Priam_Tro">
+          <person xml:id="Priam_Tro" ana="http://www.wikidata.org/entity/Q170473">
             <persName>Priam</persName>
           </person>
-          <person xml:id="Hector_Tro">
+          <person xml:id="Hector_Tro" ana="http://www.wikidata.org/entity/Q159666">
             <persName>Hector</persName>
           </person>
-          <person xml:id="Helenus_Tro">
+          <person xml:id="Helenus_Tro" ana="http://www.wikidata.org/entity/Q729332">
             <persName>Helenus</persName>
           </person>
-          <person xml:id="Cassandra_Tro">
+          <person xml:id="Cassandra_Tro" ana="http://www.wikidata.org/entity/Q170779">
             <persName>Cassandra</persName>
           </person>
-          <person xml:id="Paris_Tro">
+          <person xml:id="Paris_Tro" ana="http://www.wikidata.org/entity/Q167646">
             <persName>Paris</persName>
           </person>
-          <person xml:id="Diomedes_Tro">
+          <person xml:id="Diomedes_Tro" ana="http://www.wikidata.org/entity/Q208256">
             <persName>Diomedes</persName>
           </person>
-          <person xml:id="SERVANTS.PARIS.1_Tro">
+          <person xml:id="SERVANTS.PARIS.1_Tro" sex="MALE">
             <persName>Paris’s Servingman</persName>
           </person>
-          <person xml:id="Helen_Tro">
+          <person xml:id="Helen_Tro" ana="http://www.wikidata.org/entity/Q164061">
             <persName>Helen</persName>
           </person>
-          <person xml:id="SERVANTS.TROILUS.1_Tro">
+          <person xml:id="SERVANTS.TROILUS.1_Tro" sex="MALE">
             <persName>Troilus’s Man</persName>
           </person>
-          <person xml:id="Calchas_Tro">
+          <person xml:id="Calchas_Tro" ana="http://www.wikidata.org/entity/Q725527">
             <persName>Calchas</persName>
           </person>
-          <person xml:id="Deiphobus_Tro">
+          <person xml:id="Deiphobus_Tro" ana="http://www.wikidata.org/entity/Q736813">
             <persName>Deiphobus</persName>
           </person>
-          <person xml:id="ATTENDANTS.GREEK_Tro">
-            <persName>Other Trojans and Greeks, Common Soldiers of Troy and Greece, Trumpeters, Attendants, Torchbearers</persName>
-          </person>
-          <person xml:id="Andromache_Tro">
+          <personGrp xml:id="ATTENDANTS.GREEK_Tro" sex="UNKNOWN">
+            <name>Other Trojans and Greeks, Common Soldiers of Troy and Greece, Trumpeters, Attendants, Torchbearers</name>
+          </personGrp>
+          <person xml:id="Andromache_Tro" ana="http://www.wikidata.org/entity/Q19376">
             <persName>Andromache</persName>
           </person>
-          <person xml:id="SERVANTS.DIOMEDES.1_Tro">
+          <person xml:id="SERVANTS.DIOMEDES.1_Tro" sex="MALE">
             <persName>Diomedes’ Servingman</persName>
           </person>
-          <person xml:id="Bastard_Tro">
+          <person xml:id="Bastard_Tro" sex="MALE">
             <persName>Bastard</persName>
           </person>
-          <person xml:id="MYRMIDONS.0.1_Tro">
+          <person sex="" xml:id="MYRMIDONS.0.1_Tro">
             <persName>MYRMIDONS.0.1_Tro</persName>
           </person>
-          <person xml:id="SOLDIERS_Tro">
-            <persName>Other Trojans and Greeks, Common Soldiers of Troy and Greece, Trumpeters, Attendants, Torchbearers</persName>
-          </person>
-          <person xml:id="Antenor_Tro">
+          <personGrp xml:id="SOLDIERS_Tro" sex="UNKNOWN">
+            <name>Other Trojans and Greeks, Common Soldiers of Troy and Greece, Trumpeters, Attendants, Torchbearers</name>
+          </personGrp>
+          <person xml:id="Antenor_Tro" ana="http://www.wikidata.org/entity/Q571969">
             <persName>Antenor</persName>
           </person>
-          <person xml:id="SOLDIERS.TROJAN_Tro">
-            <persName>Other Trojans and Greeks, Common Soldiers of Troy and Greece, Trumpeters, Attendants, Torchbearers</persName>
-          </person>
+          <personGrp xml:id="SOLDIERS.TROJAN_Tro" sex="UNKNOWN">
+            <name>Other Trojans and Greeks, Common Soldiers of Troy and Greece, Trumpeters, Attendants, Torchbearers</name>
+          </personGrp>
         </listPerson>
       </particDesc>
     </profileDesc>

--- a/tei/troilus-and-cressida.xml
+++ b/tei/troilus-and-cressida.xml
@@ -179,7 +179,7 @@
           <person xml:id="Bastard_Tro" sex="MALE">
             <persName>Bastard</persName>
           </person>
-          <person sex="" xml:id="MYRMIDONS.0.1_Tro">
+          <person xml:id="MYRMIDONS.0.1_Tro">
             <persName>MYRMIDONS.0.1_Tro</persName>
           </person>
           <personGrp xml:id="SOLDIERS_Tro" sex="UNKNOWN">

--- a/tei/twelfth-night.xml
+++ b/tei/twelfth-night.xml
@@ -88,59 +88,59 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Orsino_TN">
+          <person xml:id="Orsino_TN" sex="MALE">
             <persName>Orsino</persName>
           </person>
-          <person xml:id="ATTENDANTS.ORSINO.Curio_TN">
+          <person xml:id="ATTENDANTS.ORSINO.Curio_TN" sex="MALE">
             <persName>Curio</persName>
           </person>
-          <person xml:id="ATTENDANTS.ORSINO.Valentine_TN">
+          <person xml:id="ATTENDANTS.ORSINO.Valentine_TN" sex="MALE">
             <persName>Valentine</persName>
           </person>
-          <person xml:id="Viola_TN">
+          <person xml:id="Viola_TN" sex="FEMALE">
             <persName>Viola Cesario</persName>
             <persName>Viola Cesario</persName>
           </person>
-          <person xml:id="Captain_TN">
+          <person xml:id="Captain_TN" sex="MALE">
             <persName>Captain</persName>
           </person>
-          <person xml:id="TobyBelch_TN">
+          <person xml:id="TobyBelch_TN" sex="MALE">
             <persName>Sir Toby Belch</persName>
           </person>
-          <person xml:id="Maria_TN">
+          <person xml:id="Maria_TN" sex="FEMALE">
             <persName>Maria</persName>
           </person>
-          <person xml:id="AndrewAguecheek_TN">
+          <person xml:id="AndrewAguecheek_TN" sex="MALE">
             <persName>Sir Andrew Aguecheek</persName>
           </person>
-          <person xml:id="Feste_TN">
+          <person xml:id="Feste_TN" sex="MALE">
             <persName>Fool</persName>
           </person>
-          <person xml:id="Olivia_TN">
+          <person xml:id="Olivia_TN" sex="FEMALE">
             <persName>Olivia</persName>
           </person>
-          <person xml:id="Malvolio_TN">
+          <person xml:id="Malvolio_TN" sex="MALE">
             <persName>Malvolio</persName>
           </person>
-          <person xml:id="Antonio_TN">
+          <person xml:id="Antonio_TN" sex="MALE">
             <persName>Antonio</persName>
           </person>
-          <person xml:id="Sebastian_TN">
+          <person xml:id="Sebastian_TN" sex="MALE">
             <persName>Sebastian</persName>
           </person>
-          <person xml:id="Fabian_TN">
+          <person xml:id="Fabian_TN" sex="MALE">
             <persName>Fabian</persName>
           </person>
-          <person xml:id="ATTENDANTS.OLIVIA.1_TN">
-            <persName>Lords, Sailors, Musicians, and other Attendants</persName>
-          </person>
-          <person xml:id="OFFICERS.1_TN">
+          <personGrp xml:id="ATTENDANTS.OLIVIA.1_TN" sex="UNKNOWN">
+            <name>Lords, Sailors, Musicians, and other Attendants</name>
+          </personGrp>
+          <person xml:id="OFFICERS.1_TN" sex="MALE">
             <persName>OFFICERS.1_TN</persName>
           </person>
-          <person xml:id="OFFICERS.2_TN">
+          <person xml:id="OFFICERS.2_TN" sex="MALE">
             <persName>OFFICERS.2_TN</persName>
           </person>
-          <person xml:id="Priest_TN">
+          <person xml:id="Priest_TN" sex="MALE">
             <persName>Priest</persName>
           </person>
         </listPerson>

--- a/tei/twelfth-night.xml
+++ b/tei/twelfth-night.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,66 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Orsino_TN"><persName>Orsino</persName></person><person xml:id="ATTENDANTS.ORSINO.Curio_TN"><persName>Curio</persName></person><person xml:id="ATTENDANTS.ORSINO.Valentine_TN"><persName>Valentine</persName></person><person xml:id="Viola_TN"><persName>Viola Cesario</persName><persName>Viola Cesario</persName></person><person xml:id="Captain_TN"><persName>Captain</persName></person><person xml:id="TobyBelch_TN"><persName>Sir Toby Belch</persName></person><person xml:id="Maria_TN"><persName>Maria</persName></person><person xml:id="AndrewAguecheek_TN"><persName>Sir Andrew Aguecheek</persName></person><person xml:id="Feste_TN"><persName>Fool</persName></person><person xml:id="Olivia_TN"><persName>Olivia</persName></person><person xml:id="Malvolio_TN"><persName>Malvolio</persName></person><person xml:id="Antonio_TN"><persName>Antonio</persName></person><person xml:id="Sebastian_TN"><persName>Sebastian</persName></person><person xml:id="Fabian_TN"><persName>Fabian</persName></person><person xml:id="ATTENDANTS.OLIVIA.1_TN"><persName>Lords, Sailors, Musicians, and other Attendants</persName></person><person xml:id="OFFICERS.1_TN"><persName>OFFICERS.1_TN</persName></person><person xml:id="OFFICERS.2_TN"><persName>OFFICERS.2_TN</persName></person><person xml:id="Priest_TN"><persName>Priest</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Orsino_TN">
+            <persName>Orsino</persName>
+          </person>
+          <person xml:id="ATTENDANTS.ORSINO.Curio_TN">
+            <persName>Curio</persName>
+          </person>
+          <person xml:id="ATTENDANTS.ORSINO.Valentine_TN">
+            <persName>Valentine</persName>
+          </person>
+          <person xml:id="Viola_TN">
+            <persName>Viola Cesario</persName>
+            <persName>Viola Cesario</persName>
+          </person>
+          <person xml:id="Captain_TN">
+            <persName>Captain</persName>
+          </person>
+          <person xml:id="TobyBelch_TN">
+            <persName>Sir Toby Belch</persName>
+          </person>
+          <person xml:id="Maria_TN">
+            <persName>Maria</persName>
+          </person>
+          <person xml:id="AndrewAguecheek_TN">
+            <persName>Sir Andrew Aguecheek</persName>
+          </person>
+          <person xml:id="Feste_TN">
+            <persName>Fool</persName>
+          </person>
+          <person xml:id="Olivia_TN">
+            <persName>Olivia</persName>
+          </person>
+          <person xml:id="Malvolio_TN">
+            <persName>Malvolio</persName>
+          </person>
+          <person xml:id="Antonio_TN">
+            <persName>Antonio</persName>
+          </person>
+          <person xml:id="Sebastian_TN">
+            <persName>Sebastian</persName>
+          </person>
+          <person xml:id="Fabian_TN">
+            <persName>Fabian</persName>
+          </person>
+          <person xml:id="ATTENDANTS.OLIVIA.1_TN">
+            <persName>Lords, Sailors, Musicians, and other Attendants</persName>
+          </person>
+          <person xml:id="OFFICERS.1_TN">
+            <persName>OFFICERS.1_TN</persName>
+          </person>
+          <person xml:id="OFFICERS.2_TN">
+            <persName>OFFICERS.2_TN</persName>
+          </person>
+          <person xml:id="Priest_TN">
+            <persName>Priest</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/two-gentlemen-of-verona.xml
+++ b/tei/two-gentlemen-of-verona.xml
@@ -69,7 +69,7 @@
     <encodingDesc>
       <projectDesc>
         <p>This version of the Folger Digital Texts uses TEI Simple to encode the Shakespeare texts edited by Barbara Mowat and Paul Werstine.  The major goal of recasting the texts in this manner is to make them interoperable with a large corpus of early modern texts derived from the EEBO-TCP transcriptions and encoded in TEI Simple with linguistic annotation.</p>
-        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are: 
+        <p>For a full description of the encoding practices of the Folger Digital Texts consult their <gi>encodingDesc</gi> section. This version is completely faithful to the readings, orthogrgraphy, and punctuation of the source text. It uses a different XML encoding scheme, with occasional losses in expressiveness. The major differences are:
           <list><item>Number <gi>div</gi> are replaced by unnumbered divs</item><item>Lines of verse are marked in <gi>l</gi>, tags, lines of prose in <gi>ab</gi></item><item>All xml:ids are corpuswide identifiers</item><item>Information from the participant description element <gi>particDesc</gi> in the teiHeader has been moved into  a <gi>castList</gi> element in the <gi>front</gi> element</item><item>Each spoken word in the text has been linguistically annotated with a lemma and POS tag</item></list>
         </p>
       </projectDesc>
@@ -86,7 +86,62 @@
         <language ident="la">Latin</language>
         <language ident="es">Spanish</language>
       </langUsage>
-    <particDesc><listPerson><person xml:id="Valentine_TGV"><persName>Valentine</persName></person><person xml:id="Proteus_TGV"><persName>Proteus</persName></person><person xml:id="Speed_TGV"><persName>Speed</persName></person><person xml:id="Julia_TGV"><persName>Julia</persName></person><person xml:id="Lucetta_TGV"><persName>Lucetta</persName></person><person xml:id="Antonio_TGV"><persName>Antonio</persName></person><person xml:id="Pantino_TGV"><persName>Pantino</persName></person><person xml:id="Sylvia_TGV"><persName>Sylvia</persName></person><person xml:id="Lance_TGV"><persName>Lance</persName></person><person xml:id="Thurio_TGV"><persName>Thurio</persName></person><person xml:id="Duke_TGV"><persName>Duke</persName></person><person xml:id="SERVANTS.1_TGV"><persName>SERVANTS.1_TGV</persName></person><person xml:id="OUTLAWS.1_TGV"><persName>OUTLAWS.1_TGV</persName></person><person xml:id="OUTLAWS.2_TGV"><persName>OUTLAWS.2_TGV</persName></person><person xml:id="OUTLAWS.3_TGV"><persName>OUTLAWS.3_TGV</persName></person><person xml:id="Host_TGV"><persName>Host</persName></person><person xml:id="Eglamour_TGV"><persName>Eglamour</persName></person></listPerson></particDesc></profileDesc>
+      <particDesc>
+        <listPerson>
+          <person xml:id="Valentine_TGV">
+            <persName>Valentine</persName>
+          </person>
+          <person xml:id="Proteus_TGV">
+            <persName>Proteus</persName>
+          </person>
+          <person xml:id="Speed_TGV">
+            <persName>Speed</persName>
+          </person>
+          <person xml:id="Julia_TGV">
+            <persName>Julia</persName>
+          </person>
+          <person xml:id="Lucetta_TGV">
+            <persName>Lucetta</persName>
+          </person>
+          <person xml:id="Antonio_TGV">
+            <persName>Antonio</persName>
+          </person>
+          <person xml:id="Pantino_TGV">
+            <persName>Pantino</persName>
+          </person>
+          <person xml:id="Sylvia_TGV">
+            <persName>Sylvia</persName>
+          </person>
+          <person xml:id="Lance_TGV">
+            <persName>Lance</persName>
+          </person>
+          <person xml:id="Thurio_TGV">
+            <persName>Thurio</persName>
+          </person>
+          <person xml:id="Duke_TGV">
+            <persName>Duke</persName>
+          </person>
+          <person xml:id="SERVANTS.1_TGV">
+            <persName>SERVANTS.1_TGV</persName>
+          </person>
+          <person xml:id="OUTLAWS.1_TGV">
+            <persName>OUTLAWS.1_TGV</persName>
+          </person>
+          <person xml:id="OUTLAWS.2_TGV">
+            <persName>OUTLAWS.2_TGV</persName>
+          </person>
+          <person xml:id="OUTLAWS.3_TGV">
+            <persName>OUTLAWS.3_TGV</persName>
+          </person>
+          <person xml:id="Host_TGV">
+            <persName>Host</persName>
+          </person>
+          <person xml:id="Eglamour_TGV">
+            <persName>Eglamour</persName>
+          </person>
+        </listPerson>
+      </particDesc>
+    </profileDesc>
   </teiHeader>
   <text>
     <front>

--- a/tei/two-gentlemen-of-verona.xml
+++ b/tei/two-gentlemen-of-verona.xml
@@ -88,55 +88,55 @@
       </langUsage>
       <particDesc>
         <listPerson>
-          <person xml:id="Valentine_TGV">
+          <person xml:id="$2" sex="$1">
             <persName>Valentine</persName>
           </person>
-          <person xml:id="Proteus_TGV">
+          <person xml:id="$2" sex="$1">
             <persName>Proteus</persName>
           </person>
-          <person xml:id="Speed_TGV">
+          <person xml:id="$2" sex="$1">
             <persName>Speed</persName>
           </person>
-          <person xml:id="Julia_TGV">
+          <person xml:id="$2" sex="$1">
             <persName>Julia</persName>
           </person>
-          <person xml:id="Lucetta_TGV">
+          <person xml:id="$2" sex="$1">
             <persName>Lucetta</persName>
           </person>
-          <person xml:id="Antonio_TGV">
+          <person xml:id="$2" sex="$1">
             <persName>Antonio</persName>
           </person>
-          <person xml:id="Pantino_TGV">
+          <person xml:id="$2" sex="$1">
             <persName>Pantino</persName>
           </person>
-          <person xml:id="Sylvia_TGV">
+          <person xml:id="$2" sex="$1">
             <persName>Sylvia</persName>
           </person>
-          <person xml:id="Lance_TGV">
+          <person xml:id="$2" sex="$1">
             <persName>Lance</persName>
           </person>
-          <person xml:id="Thurio_TGV">
+          <person xml:id="$2" sex="$1">
             <persName>Thurio</persName>
           </person>
-          <person xml:id="Duke_TGV">
+          <person xml:id="$2" sex="$1">
             <persName>Duke</persName>
           </person>
-          <person xml:id="SERVANTS.1_TGV">
+          <person xml:id="$2" sex="$1">
             <persName>SERVANTS.1_TGV</persName>
           </person>
-          <person xml:id="OUTLAWS.1_TGV">
+          <person xml:id="$2" sex="$1">
             <persName>OUTLAWS.1_TGV</persName>
           </person>
-          <person xml:id="OUTLAWS.2_TGV">
+          <person xml:id="$2" sex="$1">
             <persName>OUTLAWS.2_TGV</persName>
           </person>
-          <person xml:id="OUTLAWS.3_TGV">
+          <person xml:id="$2" sex="$1">
             <persName>OUTLAWS.3_TGV</persName>
           </person>
-          <person xml:id="Host_TGV">
+          <person xml:id="$2" sex="$1">
             <persName>Host</persName>
           </person>
-          <person xml:id="Eglamour_TGV">
+          <person xml:id="$2" sex="$1">
             <persName>Eglamour</persName>
           </person>
         </listPerson>


### PR DESCRIPTION
After properly indenting the generated particDesc elements,  `sex` attributes have been added for all characters. For some characters, a link to Wikidata has been added. Group characters are marked as `personGrp` (in the original markup all characters are marked as `person`). The order of characters is left as it was.
Names of the students worked on the markup were added to readme.